### PR TITLE
Update publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,12 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.KAOTO_RELEASE_APP_ID }}
+          private-key: ${{ secrets.KAOTO_RELEASE_APP_KEY }}
+          
       - name: 'Checkout source code'
         uses: actions/checkout@v4
         with:
@@ -40,7 +46,7 @@ jobs:
       # Version and publish
       - name: "Version and publish"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.KAOTO_NEXT_NPM_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
update to use tokens from kaoto-release-app to bypass the branch restrictions