### PR TITLE
add gh-pages

### DIFF
--- a/.github/workflows/publish-page.yml
+++ b/.github/workflows/publish-page.yml
@@ -1,0 +1,42 @@
+name: 🚀 Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+    steps:
+      - name: 🛎️ Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🧰 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'yarn'
+
+      - name: 📦 Install dependencies
+        run: yarn
+
+      - name: 🏗️ Build Vite site
+        run: yarn build:site
+
+      - name: 📤 Upload artifact for GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+      - name: 🚀 Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        with:
+          github_token: ${{ github.token }}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "start": "vite --mode=dev",
     "build": "yarn rimraf dist && yarn build:esm",
     "build:esm": "tsc --project tsconfig.esm.json && copyfiles -u 2 ./src/form/**/*.scss ./dist",
+    "build:site": "vite build  --config vite.config.mjs",
     "test": "jest",
     "publish": "lerna publish"
   },


### PR DESCRIPTION
This pull request introduces a workflow for deploying the project to GitHub Pages and adds a new build script for the Vite site in the `package.json` file. The changes streamline the deployment process and ensure the project's site can be built and published efficiently.

### GitHub Pages Deployment Workflow:

* [`.github/workflows/publish-page.yml`](diffhunk://#diff-8f44c558b13190496bd749f15909d17bc6e921ba64f65eb7945f3e26a1edda03R1-R42): Added a new GitHub Actions workflow named "Deploy to GitHub Pages." This workflow runs on pushes to the `main` branch, sets up permissions, installs dependencies, builds the Vite site, and deploys the resulting artifacts to GitHub Pages.

### Build Script Update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R35): Added a new script `"build:site"` to build the Vite site using the configuration file `vite.config.mjs`.