### PR TITLE
fix: cypress causing type errors in jest assertions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "./cypress.config.ts",],
   "compilerOptions": {
     "lib": ["es6", "dom", "es2018.promise", "es2019", "esnext"],
     "strict": true,


### PR DESCRIPTION
Adding cypress was causing type errors in jest. Adding workarround based on https://stackoverflow.com/questions/58999086/cypress-causing-type-errors-in-jest-assertions