### PR TITLE
chore(PasswordField): Add Suggestions for the PasswordField

### DIFF
--- a/src/form/fields/EnumField.test.tsx
+++ b/src/form/fields/EnumField.test.tsx
@@ -1,0 +1,106 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { ModelContextProvider } from '../providers/ModelProvider';
+import { SchemaProvider } from '../providers/SchemaProvider';
+import { ROOT_PATH } from '../utils';
+import { EnumField } from './EnumField';
+
+describe('EnumField', () => {
+  const enumSchema = {
+    type: 'string' as const,
+    enum: ['Option1', 'Option2', 'Option3'],
+    default: 'Option2',
+    title: 'Enum Field',
+    description: 'Choose an option',
+  };
+
+  it('renders the EnumField as a Typeahead', () => {
+    render(
+      <ModelContextProvider model={undefined} onPropertyChange={jest.fn()}>
+        <SchemaProvider schema={enumSchema}>
+          <EnumField propName={ROOT_PATH} />
+        </SchemaProvider>
+      </ModelContextProvider>,
+    );
+
+    const input = screen.getByRole('textbox', { name: /type to filter/i });
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('placeholder', 'Option2');
+  });
+
+  it('shows all enum options in the dropdown when opened', async () => {
+    render(
+      <ModelContextProvider model={undefined} onPropertyChange={jest.fn()}>
+        <SchemaProvider schema={enumSchema}>
+          <EnumField propName={ROOT_PATH} />
+        </SchemaProvider>
+      </ModelContextProvider>,
+    );
+    const input = screen.getByRole('textbox', { name: /type to filter/i });
+
+    await act(async () => {
+      fireEvent.click(input);
+    });
+
+    expect(screen.getByText('Option1')).toBeInTheDocument();
+    expect(screen.getByText('Option2')).toBeInTheDocument();
+    expect(screen.getByText('Option3')).toBeInTheDocument();
+  });
+
+  it('calls onChange when an option is selected', async () => {
+    const onPropertyChangeSpy = jest.fn();
+    render(
+      <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
+        <SchemaProvider schema={enumSchema}>
+          <EnumField propName={ROOT_PATH} />
+        </SchemaProvider>
+      </ModelContextProvider>,
+    );
+
+    const input = screen.getByRole('textbox', { name: /type to filter/i });
+
+    await act(async () => {
+      fireEvent.click(input);
+    });
+
+    const option2 = await screen.findByText('Option2');
+    act(() => {
+      fireEvent.click(option2);
+    });
+
+    expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, 'Option2');
+  });
+
+  it('calls onCleanInput when the clear button is clicked', async () => {
+    const onPropertyChangeSpy = jest.fn();
+    render(
+      <ModelContextProvider model={'Option1'} onPropertyChange={onPropertyChangeSpy}>
+        <SchemaProvider schema={enumSchema}>
+          <EnumField propName={ROOT_PATH} />
+        </SchemaProvider>
+      </ModelContextProvider>,
+    );
+
+    const clearButton = screen.getByLabelText('Clear input value');
+    act(() => {
+      fireEvent.click(clearButton);
+    });
+
+    expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, undefined);
+  });
+
+  it('shows errors if available for its property path', () => {
+    const onPropertyChangeSpy = jest.fn();
+    render(
+      <ModelContextProvider
+        model={'Option1'}
+        errors={{ [ROOT_PATH]: ['error message'] }}
+        onPropertyChange={onPropertyChangeSpy}
+      >
+        <SchemaProvider schema={enumSchema}>
+          <EnumField propName={ROOT_PATH} />
+        </SchemaProvider>
+      </ModelContextProvider>,
+    );
+    expect(screen.getByText(/error message/i)).toBeInTheDocument();
+  });
+});

--- a/src/form/fields/EnumField.tsx
+++ b/src/form/fields/EnumField.tsx
@@ -9,7 +9,7 @@ import { isDefined } from '../utils';
 
 export const EnumField: FunctionComponent<FieldProps> = ({ propName, required }) => {
   const { schema } = useContext(SchemaContext);
-  const { value = '', onChange, disabled } = useFieldValue<string | undefined>(propName);
+  const { value = '', onChange, disabled, errors } = useFieldValue<string | undefined>(propName);
   if (!isDefined(schema)) {
     throw new Error(`StringField: schema is not defined for ${propName}`);
   }
@@ -57,6 +57,7 @@ export const EnumField: FunctionComponent<FieldProps> = ({ propName, required })
       propName={propName}
       required={required}
       title={schema.title}
+      errors={errors}
       type="enum"
       description={schema.description}
       defaultValue={schema.default?.toString()}

--- a/src/form/fields/PasswordField.tsx
+++ b/src/form/fields/PasswordField.tsx
@@ -1,10 +1,11 @@
 import { Button, TextInputGroup, TextInputGroupMain, TextInputGroupUtilities } from '@patternfly/react-core';
 import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
-import { FunctionComponent, useContext, useRef, useState } from 'react';
-import { isDefined, isRawString } from '../utils';
+import { FunctionComponent, useCallback, useContext, useRef, useState } from 'react';
 import { useFieldValue } from '../hooks/field-value';
-import { SchemaContext } from '../providers/SchemaProvider';
+import { useSuggestions } from '../hooks/suggestions';
 import { FieldProps } from '../models/typings';
+import { SchemaContext } from '../providers/SchemaProvider';
+import { isDefined, isRawString } from '../utils';
 import { FieldActions } from './FieldActions';
 import { FieldWrapper } from './FieldWrapper';
 
@@ -18,9 +19,12 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
   const toggleRawAriaLabel = `Toggle RAW wrap for ${lastPropName} field`;
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const onFieldChange = (_event: unknown, value: string) => {
-    onChange(value);
-  };
+  const onFieldChange = useCallback(
+    (_event: unknown, value: string) => {
+      onChange(value);
+    },
+    [onChange],
+  );
 
   const onRemove = () => {
     if (isDefined(onRemoveProps)) {
@@ -39,6 +43,21 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
     const newValue = isRawString(value) ? value.substring(4, value.length - 1) : `RAW(${value})`;
     onChange(newValue);
   };
+
+  const setValue = useCallback(
+    (value: string | number) => {
+      onFieldChange(null, value.toString());
+    },
+    [onFieldChange],
+  );
+
+  const suggestions = useSuggestions({
+    propName,
+    schema,
+    inputRef,
+    value,
+    setValue,
+  });
 
   const id = `${propName}-popover`;
 
@@ -66,6 +85,8 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
           aria-describedby={id}
           ref={inputRef}
         />
+
+        {suggestions}
 
         <TextInputGroupUtilities>
           <Button

--- a/src/form/index.ts
+++ b/src/form/index.ts
@@ -2,6 +2,7 @@
 export * from './fields';
 export * from './hooks';
 export * from './KaotoForm';
+export * from './models/suggestions';
 export * from './models/typings';
 export * from './providers';
 export * from './utils';


### PR DESCRIPTION
### Context
This commit adds Suggestions for the `PasswordField` and adds missing tests for other components.

relates: https://github.com/KaotoIO/kaoto/issues/494