### PR TITLE
fox(BooleanField): Use schema default value

### DIFF
--- a/src/form/fields/BooleanField.test.tsx
+++ b/src/form/fields/BooleanField.test.tsx
@@ -1,0 +1,84 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import { ModelContextProvider } from '../providers/ModelProvider';
+import { SchemaProvider } from '../providers/SchemaProvider';
+import { ROOT_PATH } from '../utils';
+import { BooleanField } from './BooleanField';
+
+describe('BooleanField', () => {
+  const renderWithProviders = (children: React.ReactNode) => {
+    return render(
+      <ModelContextProvider model={false} onPropertyChange={jest.fn()}>
+        <SchemaProvider
+          schema={{ type: 'boolean', title: 'Boolean Field', description: 'A boolean field', default: false }}
+        >
+          {children}
+        </SchemaProvider>
+      </ModelContextProvider>,
+    );
+  };
+
+  it('should render with default props', () => {
+    const { getByRole } = renderWithProviders(<BooleanField propName={ROOT_PATH} />);
+    const checkbox = getByRole('checkbox');
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('should render checked if value is true', () => {
+    const { getByRole } = render(
+      <ModelContextProvider model={true} onPropertyChange={jest.fn()}>
+        <SchemaProvider schema={{ type: 'boolean', title: 'Boolean Field', default: false }}>
+          <BooleanField propName={ROOT_PATH} />
+        </SchemaProvider>
+      </ModelContextProvider>,
+    );
+    const checkbox = getByRole('checkbox');
+    expect(checkbox).toBeChecked();
+  });
+
+  it('should use schema default if value is undefined', () => {
+    const { getByRole } = render(
+      <ModelContextProvider model={undefined} onPropertyChange={jest.fn()}>
+        <SchemaProvider schema={{ type: 'boolean', title: 'Boolean Field', default: true }}>
+          <BooleanField propName={ROOT_PATH} />
+        </SchemaProvider>
+      </ModelContextProvider>,
+    );
+    const checkbox = getByRole('checkbox');
+    expect(checkbox).toBeChecked();
+  });
+
+  it('should call onChange when toggled', () => {
+    const onPropertyChange = jest.fn();
+    const { getByRole } = render(
+      <ModelContextProvider model={false} onPropertyChange={onPropertyChange}>
+        <SchemaProvider schema={{ type: 'boolean', title: 'Boolean Field', default: false }}>
+          <BooleanField propName={ROOT_PATH} />
+        </SchemaProvider>
+      </ModelContextProvider>,
+    );
+    const checkbox = getByRole('checkbox');
+    act(() => {
+      fireEvent.click(checkbox);
+    });
+    expect(onPropertyChange).toHaveBeenCalledWith(ROOT_PATH, true);
+  });
+
+  it('should be disabled if disabled from context', () => {
+    const { getByRole } = render(
+      <ModelContextProvider model={false} onPropertyChange={jest.fn()} disabled>
+        <SchemaProvider schema={{ type: 'boolean', title: 'Boolean Field', default: false }}>
+          <BooleanField propName={ROOT_PATH} />
+        </SchemaProvider>
+      </ModelContextProvider>,
+    );
+    const checkbox = getByRole('checkbox');
+    expect(checkbox).toBeDisabled();
+  });
+
+  it('should pass required prop to FieldWrapper', () => {
+    const { getByText } = renderWithProviders(<BooleanField propName={ROOT_PATH} required />);
+    // Should render the title, which is passed to FieldWrapper
+    expect(getByText('Boolean Field')).toBeInTheDocument();
+  });
+});

--- a/src/form/fields/BooleanField.tsx
+++ b/src/form/fields/BooleanField.tsx
@@ -14,6 +14,12 @@ export const BooleanField: FunctionComponent<FieldProps> = ({ propName, required
 
   const id = `${propName}-popover`;
 
+  let normalizedValue = value;
+  if (normalizedValue === undefined) {
+    // If the value is undefined, we check the schema default. Sometimes the default is not set, so we use false.
+    normalizedValue = schema.default === true;
+  }
+
   return (
     <FieldWrapper
       propName={propName}
@@ -30,8 +36,8 @@ export const BooleanField: FunctionComponent<FieldProps> = ({ propName, required
         role="checkbox"
         aria-label={schema.title}
         aria-describedby={id}
-        isChecked={value}
-        checked={value}
+        isChecked={normalizedValue}
+        checked={normalizedValue}
         onChange={onFieldChange}
         isDisabled={disabled}
       />


### PR DESCRIPTION
### Context
Currently, `BooleanField` it's not respecting the schema's default value when the value is undefined or not specified in the model.

This commit checks the value coming from the model and use the default value from the schema if provided.

| Before | After |
| --- | --- |
| <img width="970" height="254" alt="image" src="https://github.com/user-attachments/assets/60f4c10f-e0af-4a0f-ae03-c6d8dbbd126b" /> | <img width="970" height="254" alt="image" src="https://github.com/user-attachments/assets/8c639d97-7ea9-4b18-a4c1-deac2cddb96d" /> |

fix: https://github.com/KaotoIO/kaoto/issues/2391