### PR TITLE
fix(Suggestions): Click on a group crash the app

### DIFF
--- a/src/form/hooks/suggestions.test.tsx
+++ b/src/form/hooks/suggestions.test.tsx
@@ -443,6 +443,35 @@ describe('useSuggestions', () => {
         expect(result.getByText('TestGroup')).toBeInTheDocument();
       });
     });
+
+    it('should not render empty groups', async () => {
+      mockProvider.getSuggestions = jest.fn().mockResolvedValue([
+        { value: 'root1', description: 'Root suggestion' },
+        { value: 'grouped1', description: 'Grouped suggestion', group: 'TestGroup' },
+      ]);
+
+      const result = renderWithContext(<TestComponent />);
+
+      await act(async () => {
+        fireEvent.keyDown(result.getByTestId('test-input'), { ctrlKey: true, code: 'Space' });
+      });
+
+      await waitFor(() => {
+        expect(result.getByText('root1')).toBeInTheDocument();
+        expect(result.getByText('TestGroup')).toBeInTheDocument();
+      });
+
+      // Filter suggestions to make TestGroup empty
+      await act(async () => {
+        const searchInput = result.getByTestId('suggestions-menu-search-input').querySelector('input');
+        fireEvent.change(searchInput!, { target: { value: 'root' } });
+      });
+
+      await waitFor(() => {
+        expect(result.getByText('root1')).toBeInTheDocument();
+        expect(result.queryByText('TestGroup')).not.toBeInTheDocument();
+      });
+    });
   });
 
   it('should handle async suggestion providers', async () => {

--- a/src/form/hooks/suggestions.tsx
+++ b/src/form/hooks/suggestions.tsx
@@ -173,7 +173,7 @@ export const useSuggestions = ({ propName, schema, inputRef, value, setValue }: 
       popperRef={menuRef}
       popper={
         <div ref={menuRef}>
-          <Menu containsFlyout data-testid="suggestions-menu">
+          <Menu containsFlyout isNavFlyout data-testid="suggestions-menu">
             <MenuContent>
               <MenuList>
                 <MenuItem data-testid="suggestions-menu-search-item" onFocus={focusOnSearchInput}>
@@ -188,6 +188,8 @@ export const useSuggestions = ({ propName, schema, inputRef, value, setValue }: 
                 </MenuItem>
 
                 {Object.entries(groupedSuggestions).map(([group, suggestions], groupIndex) => {
+                  if (suggestions.length === 0) return null;
+
                   if (group === 'root') {
                     return suggestions.map((suggestion, suggestionIndex) => {
                       const isFirst = groupIndex === 0 && suggestionIndex === 0;


### PR DESCRIPTION
### Context
Currently, clicking on a Suggestion group causes the app to crash because Patternfly tries to read an element that sometimes it's not there.

### Changes
The fix is to use isNavFlyout so the DOM structure is properly initialized.

fix: https://github.com/KaotoIO/kaoto/issues/2501