### PR TITLE
fix(Forms): Click on flyOut group crashes the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "usehooks-ts": "^3.0.0"
   },
   "peerDependencies": {
-    "@patternfly/patternfly": "^6.2.0",
-    "@patternfly/react-core": "^6.2.0",
-    "@patternfly/react-icons": "^6.2.0",
+    "@patternfly/patternfly": "^6.3.0",
+    "@patternfly/react-core": "6.3.1-prerelease.13",
+    "@patternfly/react-icons": "^6.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -62,10 +62,10 @@
     "@lerna-lite/cli": "^3.0.0",
     "@lerna-lite/publish": "^3.0.0",
     "@lerna-lite/version": "^3.0.0",
-    "@patternfly/patternfly": "^6.2.3",
-    "@patternfly/react-code-editor": "^6.2.2",
-    "@patternfly/react-core": "^6.2.2",
-    "@patternfly/react-icons": "^6.2.2",
+    "@patternfly/patternfly": "^6.3.0",
+    "@patternfly/react-code-editor": "6.3.1-prerelease.13",
+    "@patternfly/react-core": "6.3.1-prerelease.13",
+    "@patternfly/react-icons": "^6.3.0",
     "@swc/core": "^1.7.14",
     "@swc/jest": "^0.2.36",
     "@testing-library/dom": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,10 +2592,10 @@ __metadata:
     "@lerna-lite/cli": "npm:^3.0.0"
     "@lerna-lite/publish": "npm:^3.0.0"
     "@lerna-lite/version": "npm:^3.0.0"
-    "@patternfly/patternfly": "npm:^6.2.3"
-    "@patternfly/react-code-editor": "npm:^6.2.2"
-    "@patternfly/react-core": "npm:^6.2.2"
-    "@patternfly/react-icons": "npm:^6.2.2"
+    "@patternfly/patternfly": "npm:^6.3.0"
+    "@patternfly/react-code-editor": "npm:6.3.1-prerelease.13"
+    "@patternfly/react-core": "npm:6.3.1-prerelease.13"
+    "@patternfly/react-icons": "npm:^6.3.0"
     "@swc/core": "npm:^1.7.14"
     "@swc/jest": "npm:^0.2.36"
     "@testing-library/dom": "npm:^10.0.0"
@@ -2643,9 +2643,9 @@ __metadata:
     vite-plugin-dts: "npm:^4.5.4"
     vite-plugin-static-copy: "npm:^3.1.0"
   peerDependencies:
-    "@patternfly/patternfly": ^6.2.0
-    "@patternfly/react-core": ^6.2.0
-    "@patternfly/react-icons": ^6.2.0
+    "@patternfly/patternfly": ^6.3.0
+    "@patternfly/react-core": 6.3.1-prerelease.13
+    "@patternfly/react-icons": ^6.3.0
     react: ^18.2.0
     react-dom: ^18.2.0
   languageName: unknown
@@ -3300,68 +3300,85 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/patternfly@npm:^6.2.3":
-  version: 6.2.3
-  resolution: "@patternfly/patternfly@npm:6.2.3"
-  checksum: 10/e23fa66930e4a9a81693b6775cedb2b308d625bc94903509b31fdbfdd61f84eac68bd8d6456a9877bcf9785fbee5b34dc526e34ac52c716701455bb86a36e592
+"@patternfly/patternfly@npm:^6.3.0":
+  version: 6.3.1
+  resolution: "@patternfly/patternfly@npm:6.3.1"
+  checksum: 10/54b03987ca1cc2086c64d7eb0b243f9e04964f0c7f8642d82559b6efeb4896d8d9f0246c032a0071fb13e2e17ea2c25e741014460874a203af58a36b0fd28c2b
   languageName: node
   linkType: hard
 
-"@patternfly/react-code-editor@npm:^6.2.2":
-  version: 6.2.2
-  resolution: "@patternfly/react-code-editor@npm:6.2.2"
+"@patternfly/react-code-editor@npm:6.3.1-prerelease.13":
+  version: 6.3.1-prerelease.13
+  resolution: "@patternfly/react-code-editor@npm:6.3.1-prerelease.13"
   dependencies:
     "@monaco-editor/react": "npm:^4.6.0"
-    "@patternfly/react-core": "npm:^6.2.2"
-    "@patternfly/react-icons": "npm:^6.2.2"
-    "@patternfly/react-styles": "npm:^6.2.2"
+    "@patternfly/react-core": "npm:^6.3.1-prerelease.13"
+    "@patternfly/react-icons": "npm:^6.3.1-prerelease.0"
+    "@patternfly/react-styles": "npm:^6.3.1-prerelease.0"
     react-dropzone: "npm:14.3.5"
     tslib: "npm:^2.8.1"
   peerDependencies:
-    react: ^17 || ^18
-    react-dom: ^17 || ^18
-  checksum: 10/b292869d290450d133f125d8f677ec2f4372c2f7a6eb21e46d3b08e631f9f7e8416885b10613e3c877a69ba20045378ac302daee2936ba9483ed9e5b44124879
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  checksum: 10/62e2be2c3a421770676e82efe4a53b57d56f9d1cb5b65c14e26535b9654ba95f82c2eed000343fe5ba401ad61eee7a46641cb2cdb6bad1ba43237bb94bbef2e5
   languageName: node
   linkType: hard
 
-"@patternfly/react-core@npm:^6.2.2":
-  version: 6.2.2
-  resolution: "@patternfly/react-core@npm:6.2.2"
+"@patternfly/react-core@npm:6.3.1-prerelease.13":
+  version: 6.3.1-prerelease.13
+  resolution: "@patternfly/react-core@npm:6.3.1-prerelease.13"
   dependencies:
-    "@patternfly/react-icons": "npm:^6.2.2"
-    "@patternfly/react-styles": "npm:^6.2.2"
-    "@patternfly/react-tokens": "npm:^6.2.2"
+    "@patternfly/react-icons": "npm:^6.3.1-prerelease.0"
+    "@patternfly/react-styles": "npm:^6.3.1-prerelease.0"
+    "@patternfly/react-tokens": "npm:^6.3.1-prerelease.0"
     focus-trap: "npm:7.6.4"
     react-dropzone: "npm:^14.3.5"
     tslib: "npm:^2.8.1"
   peerDependencies:
-    react: ^17 || ^18
-    react-dom: ^17 || ^18
-  checksum: 10/7e644f8f22f6a9aa64fb72bfffb606c35b2136a4bfbfd4c0d8104a7d41c2417d9f83b62a15ca68989882ac7f91dc819cecea26edd38ea1a793124a8d44d2409c
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  checksum: 10/916dd7695c1fce5a5664b4cab2c66dfa51ef9ce59f7d38c9aaf7ac98c1fa60b86a82aaa53453f6687124dc2a4bfcc816d86622a6c6882d9ca322dcd4aaad9c93
   languageName: node
   linkType: hard
 
-"@patternfly/react-icons@npm:^6.2.2":
-  version: 6.2.2
-  resolution: "@patternfly/react-icons@npm:6.2.2"
+"@patternfly/react-core@npm:^6.3.1-prerelease.13":
+  version: 6.3.1
+  resolution: "@patternfly/react-core@npm:6.3.1"
+  dependencies:
+    "@patternfly/react-icons": "npm:^6.3.1"
+    "@patternfly/react-styles": "npm:^6.3.1"
+    "@patternfly/react-tokens": "npm:^6.3.1"
+    focus-trap: "npm:7.6.4"
+    react-dropzone: "npm:^14.3.5"
+    tslib: "npm:^2.8.1"
   peerDependencies:
-    react: ^17 || ^18
-    react-dom: ^17 || ^18
-  checksum: 10/24c37285185eb5db7a584b4468efd562685b72976f0077f68e01675f9ec16999ce686526c1e15385a7e6cc9fb11c495ab2bd06b7fa77375e48ebf7f15133b90b
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  checksum: 10/a1198b5863a6a2bf28b9e8b70f6c484a983b2ea5af066bba2581b6f4787e68b92d998078dbdbd3110b9c3ecee3370f41447e368324cf1cee930b3bb8214cb17e
   languageName: node
   linkType: hard
 
-"@patternfly/react-styles@npm:^6.2.2":
-  version: 6.2.2
-  resolution: "@patternfly/react-styles@npm:6.2.2"
-  checksum: 10/060cea589933778af3920171ba6c34b3e532c1706aa8a20fb7486645755c131f5cd5c160d32f789c48f1e63d141585b2bfe4ad982d27ccb43bb0de4642989162
+"@patternfly/react-icons@npm:^6.3.0, @patternfly/react-icons@npm:^6.3.1, @patternfly/react-icons@npm:^6.3.1-prerelease.0":
+  version: 6.3.1
+  resolution: "@patternfly/react-icons@npm:6.3.1"
+  peerDependencies:
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  checksum: 10/fbed01b0fc7083ea3bd920f02da8131afc651c53009d4430bec1e6e70891e113855006dcc57dbafaa6690ba990e0e95ba490bf36cf48eed4d73b14c94b15ea0b
   languageName: node
   linkType: hard
 
-"@patternfly/react-tokens@npm:^6.2.2":
-  version: 6.2.2
-  resolution: "@patternfly/react-tokens@npm:6.2.2"
-  checksum: 10/1066728401f6a51e65342881e46ac6b2ead11cf1d59d94b205ccf81defff9c8e5dc770d119deeab7e6f7ff6418787ae887f59039f89f2746df4c4b7ebca06ebb
+"@patternfly/react-styles@npm:^6.3.1, @patternfly/react-styles@npm:^6.3.1-prerelease.0":
+  version: 6.3.1
+  resolution: "@patternfly/react-styles@npm:6.3.1"
+  checksum: 10/a7669833906a8fe373bf9b37853aeb5ba8479a161b7885a4520ffd054c5d0cb6d3058d96d6f38b41dcf48c1b142475ae38f6a9bc777afb0305947fd0bd690d78
+  languageName: node
+  linkType: hard
+
+"@patternfly/react-tokens@npm:^6.3.1, @patternfly/react-tokens@npm:^6.3.1-prerelease.0":
+  version: 6.3.1
+  resolution: "@patternfly/react-tokens@npm:6.3.1"
+  checksum: 10/5dfc1b6b172b23a86c4d1821c556daaeb26db44a0f3c6c175e263a7b22514d3402187f579de1e4cd5571eebd5d96cf0cf3d8c070e40fbdc93f1f0bb53b61939b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Context
Introduces the fix for the issue by updating `@patternfly/*` dependencies

fix: https://github.com/KaotoIO/kaoto/issues/2501
fix: https://github.com/KaotoIO/kaoto/issues/2535
relates: https://github.com/patternfly/patternfly-react/pull/11993