### PR TITLE
feat: Add required indication for the ArrayField

### DIFF
--- a/src/form/fields/ArrayField/ArrayField.tsx
+++ b/src/form/fields/ArrayField/ArrayField.tsx
@@ -8,7 +8,7 @@ import { getHexaDecimalRandomId, getItemFromSchema, isDefined } from '../../util
 import { AutoField } from '../AutoField';
 import { ArrayFieldWrapper } from './ArrayFieldWrapper';
 
-export const ArrayField: FunctionComponent<FieldProps> = ({ propName }) => {
+export const ArrayField: FunctionComponent<FieldProps> = ({ propName, required }) => {
   const { schema, definitions } = useContext(SchemaContext);
   const { value, onChange, disabled } = useFieldValue<unknown[]>(propName);
   const [itemsHash, setItemsHash] = useState<string[]>([]);
@@ -40,6 +40,7 @@ export const ArrayField: FunctionComponent<FieldProps> = ({ propName }) => {
 
   return (
     <ArrayFieldWrapper
+      required={required}
       propName={propName}
       type="array"
       title={label}

--- a/src/form/fields/ArrayField/ArrayFieldWrapper.tsx
+++ b/src/form/fields/ArrayField/ArrayFieldWrapper.tsx
@@ -16,6 +16,7 @@ interface FieldWrapperProps {
   description?: string;
   defaultValue?: unknown;
   actions?: ReactNode;
+  required?: boolean;
 }
 
 export const ArrayFieldWrapper: FunctionComponent<PropsWithChildren<FieldWrapperProps>> = ({
@@ -26,6 +27,7 @@ export const ArrayFieldWrapper: FunctionComponent<PropsWithChildren<FieldWrapper
   defaultValue,
   actions,
   children,
+  required,
 }) => {
   const id = `${title}-popover`;
 
@@ -36,6 +38,11 @@ export const ArrayFieldWrapper: FunctionComponent<PropsWithChildren<FieldWrapper
     <Card data-testid={`${propName}__field-wrapper`}>
       <CardHeader actions={cardActions}>
         <CardTitle>
+          {required && (
+            <span className="pf-v6-c-form__label-required" aria-hidden="true">
+              *{' '}
+            </span>
+          )}{' '}
           {title}{' '}
           <Popover
             id={id}

--- a/src/form/fields/ObjectField/ObjectField.tsx
+++ b/src/form/fields/ObjectField/ObjectField.tsx
@@ -8,7 +8,7 @@ import { FieldProps } from '../../models/typings';
 import { ArrayFieldWrapper } from '../ArrayField/ArrayFieldWrapper';
 import { ObjectFieldGrouping } from './ObjectFieldGrouping';
 
-export const ObjectField: FunctionComponent<FieldProps> = ({ propName, onRemove: onRemoveProps }) => {
+export const ObjectField: FunctionComponent<FieldProps> = ({ propName, required, onRemove: onRemoveProps }) => {
   const { schema } = useContext(SchemaContext);
   const { value, onChange } = useFieldValue<object>(propName);
   const [isExpanded, setIsExpanded] = useState(isDefined(value));
@@ -38,6 +38,7 @@ export const ObjectField: FunctionComponent<FieldProps> = ({ propName, onRemove:
       propName={propName}
       type="object"
       title={label}
+      required={required}
       description={schema.description}
       defaultValue={schema.default}
       actions={


### PR DESCRIPTION

This pull request adds support for displaying required field indicators in array and object fields in the form. The main changes involve passing the `required` prop through the field components and updating the UI to show a required marker when appropriate.

(Exception's array of OnException in this example)
<img width="360" height="320" alt="Screenshot 2025-10-06 at 14 43 48" src="https://github.com/user-attachments/assets/f32f4b3b-cb68-48c0-b5b2-f7c9234b9888" />
