### PR TITLE
Fix(2617): Add Wrapper for the oneOfField

### DIFF
--- a/src/form/fields/OneOfField/OneOfField.tsx
+++ b/src/form/fields/OneOfField/OneOfField.tsx
@@ -1,12 +1,30 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useContext } from 'react';
 import { useOneOfField } from '../../hooks/one-of-field';
-import { SchemaProvider } from '../../providers/SchemaProvider';
+import { SchemaContext, SchemaProvider } from '../../providers/SchemaProvider';
 import { FieldProps } from '../../models/typings';
 import { AutoField } from '../AutoField';
 import { SchemaList } from './SchemaList';
+import { ArrayFieldWrapper } from '../ArrayField/ArrayFieldWrapper';
 
-export const OneOfField: FunctionComponent<FieldProps> = ({ propName }) => {
+export const OneOfField: FunctionComponent<FieldProps> = ({ propName, required }) => {
   const { selectedOneOfSchema, oneOfSchemas, onSchemaChange, shouldRender } = useOneOfField(propName);
+  const { schema } = useContext(SchemaContext);
+  let title = 'Type';
+  switch (schema.format) {
+    case 'dataFormatType':
+      title = 'Data Format Type';
+      break;
+    case 'loadBalancerType':
+      title = 'Load Balancer Type';
+      break;
+    case 'expression':
+    case 'expressionProperty':
+      title = 'Expression';
+      break;
+    case 'errorHandlerType':
+      title = 'Error Handler Type';
+      break;
+  }
 
   const onCleanInput = () => {
     onSchemaChange();
@@ -17,20 +35,29 @@ export const OneOfField: FunctionComponent<FieldProps> = ({ propName }) => {
   }
 
   return (
-    <SchemaList
+    <ArrayFieldWrapper
       propName={propName}
-      selectedSchema={selectedOneOfSchema}
-      schemas={oneOfSchemas}
-      onChange={onSchemaChange}
-      onCleanInput={onCleanInput}
-      aria-label={`${propName} oneof list`}
-      data-testid={`${propName}__oneof-list`}
+      type="expression"
+      title={selectedOneOfSchema?.name ?? title}
+      description={selectedOneOfSchema?.description}
+      actions={
+        <SchemaList
+          aria-label={`${propName} oneof list`}
+          data-testid={`${propName}__oneof-list`}
+          propName={propName}
+          selectedSchema={selectedOneOfSchema}
+          schemas={oneOfSchemas}
+          onChange={onSchemaChange}
+          onCleanInput={onCleanInput}
+          placeholder={`Select or write the ${title}`}
+        />
+      }
     >
       {selectedOneOfSchema && (
         <SchemaProvider schema={selectedOneOfSchema.schema}>
-          <AutoField propName={propName} />
+          <AutoField propName={propName} required={required} />
         </SchemaProvider>
       )}
-    </SchemaList>
+    </ArrayFieldWrapper>
   );
 };


### PR DESCRIPTION
### Context
Uses the newly added `format` property for the root `OneOf` schemas for:
* DataFormat (marshal, unmarshal)
* LoadBalancer
* ErrorHandler

fixes https://github.com/KaotoIO/kaoto/issues/2617
relates: https://github.com/KaotoIO/camel-catalog/pull/31