### PR TITLE
feat(Forms): Add alternate shortcut for suggestions

### DIFF
--- a/cypress/e2e/suggestionsFields.cy.ts
+++ b/cypress/e2e/suggestionsFields.cy.ts
@@ -3,7 +3,19 @@ describe('Test for suggestions for form fields', () => {
     cy.openHomePage();
   });
 
-  it('Sample App - suggestions in String form field', () => {
+  it('Sample App - suggestions in String form field using Alt+Escape shortcut', () => {
+    cy.selectSchema('timer');
+    cy.get('input[name="#.timerName"]').clear().type('testTimerName');
+
+    // Simulate Alt+Escape key combo
+    cy.get('input[name="#.timerName"]').type('{alt}{esc}');
+
+    cy.get('span').contains('{{testTimerName:default}}').click();
+
+    cy.checkCodeSpanLine('"timerName": "{{testTimerName:default}}"', 1);
+  });
+
+  it.only('Sample App - suggestions in String form field', () => {
     cy.selectSchema('timer');
     cy.get('input[name="#.timerName"]').clear().type('testTimerName');
 

--- a/src/form/hooks/suggestions.tsx
+++ b/src/form/hooks/suggestions.tsx
@@ -42,7 +42,7 @@ export const useSuggestions = ({ propName, schema, inputRef, value, setValue }: 
     (event: Event) => {
       if (!(event instanceof KeyboardEvent)) return;
 
-      if (event.ctrlKey && event.code === 'Space') {
+if ((event.ctrlKey && event.code === 'Space') || (event.altKey && event.code === 'Escape')) {
         event.preventDefault();
         setSearchValue('');
         setIsVisible(true);


### PR DESCRIPTION
Adding `alt + ESC` (`Option + ESC` on Macs) since it is one of the default key combinations to trigger autocompletion in vscode.

relates: https://github.com/KaotoIO/kaoto/issues/2563