### PR TITLE
 feat(Suggestions): Add lightbulb button and double-click to open suggestions

### DIFF
--- a/src/form/KaotoForm.scss
+++ b/src/form/KaotoForm.scss
@@ -42,6 +42,22 @@
     justify-content: space-between;
   }
 
+  &__suggestions-button {
+    display: none;
+  }
+
+  /* stylelint-disable-next-line selector-class-pattern */
+  .pf-v6-c-text-input-group:hover &__suggestions-button,
+  /* stylelint-disable-next-line selector-class-pattern */
+  .pf-v6-c-text-input-group:focus-within &__suggestions-button,
+  /* stylelint-disable-next-line selector-class-pattern */
+  .pf-v6-c-input-group:hover &__suggestions-button,
+  /* stylelint-disable-next-line selector-class-pattern */
+  .pf-v6-c-input-group:focus-within &__suggestions-button,
+  &__suggestions-button:focus {
+    display: inline-flex;
+  }
+
   &__empty {
     display: none;
   }

--- a/src/form/KeyValue/KeyValueField.test.tsx
+++ b/src/form/KeyValue/KeyValueField.test.tsx
@@ -3,7 +3,10 @@ import { KeyValueField } from './KeyValueField';
 
 // Mock useSuggestions to control its output
 jest.mock('../hooks/suggestions', () => ({
-  useSuggestions: jest.fn(() => null),
+  useSuggestions: jest.fn(() => ({
+    suggestionsMenu: null,
+    openSuggestions: jest.fn(),
+  })),
 }));
 
 describe('KeyValueField', () => {
@@ -75,7 +78,10 @@ describe('KeyValueField', () => {
     const SuggestionsMenu = () => <div data-testid="suggestions-menu">Suggestions</div>;
     const { useSuggestions } = jest.requireMock('../hooks/suggestions');
 
-    useSuggestions.mockImplementation(() => <SuggestionsMenu />);
+    useSuggestions.mockImplementation(() => ({
+      suggestionsMenu: <SuggestionsMenu />,
+      openSuggestions: jest.fn(),
+    }));
 
     const { getByTestId } = render(<KeyValueField {...defaultProps} />);
     const input = getByTestId('keyvalue-input');

--- a/src/form/KeyValue/KeyValueField.tsx
+++ b/src/form/KeyValue/KeyValueField.tsx
@@ -22,7 +22,7 @@ export const KeyValueField = forwardRef<HTMLInputElement, KeyValueFieldProps>(
 
     useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
 
-    const suggestions = useSuggestions({
+    const { suggestionsMenu } = useSuggestions({
       propName: name,
       schema: STRING_SCHEMA,
       inputRef,
@@ -47,7 +47,7 @@ export const KeyValueField = forwardRef<HTMLInputElement, KeyValueFieldProps>(
           value={value}
         />
 
-        {suggestions}
+        {suggestionsMenu}
       </TextInputGroup>
     );
   },

--- a/src/form/__snapshots__/KaotoForm.test.tsx.snap
+++ b/src/form/__snapshots__/KaotoForm.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`KaotoForm should validate the model 1`] = `
             <span
               aria-label="More info for Name field"
               class="pf-v6-c-button pf-m-plain pf-m-no-padding"
-              data-ouia-component-id="OUIA-Generated-Button-plain-7"
+              data-ouia-component-id="OUIA-Generated-Button-plain-13"
               data-ouia-component-type="PF6/Button"
               data-ouia-safe="true"
               role="button"
@@ -119,6 +119,34 @@ exports[`KaotoForm should validate the model 1`] = `
           <div
             class="pf-v6-c-text-input-group__utilities"
           >
+            <button
+              aria-label="Open suggestions"
+              class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+              data-ouia-component-id="OUIA-Generated-Button-plain-14"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              data-testid="#.name__open-suggestions-button"
+              title="Open suggestions (Ctrl+Space)"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-button__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                  />
+                </svg>
+              </span>
+            </button>
             <button
               aria-expanded="false"
               aria-label="#.name__field-actions"

--- a/src/form/fields/FieldActions.test.tsx
+++ b/src/form/fields/FieldActions.test.tsx
@@ -35,7 +35,7 @@ describe('FieldActions', () => {
       fireEvent.click(toggle);
     });
 
-    expect(wrapper.queryByTestId('testProp__clear')).not.toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('calls onRemove when Clear is clicked', async () => {

--- a/src/form/fields/PasswordField.test.tsx
+++ b/src/form/fields/PasswordField.test.tsx
@@ -1,9 +1,25 @@
 import { act, fireEvent, render, waitFor, within } from '@testing-library/react';
+import { ReactNode, useState } from 'react';
 import { ModelContextProvider } from '../providers/ModelProvider';
 import { SchemaProvider } from '../providers/SchemaProvider';
 import { SuggestionContext } from '../providers/SuggestionRegistryProvider';
 import { ROOT_PATH } from '../utils';
 import { PasswordField } from './PasswordField';
+
+const StatefulSuggestionProvider = ({
+  children,
+  getProviders,
+}: {
+  children: ReactNode;
+  getProviders: jest.Mock;
+}) => {
+  const [currentOpenMenu, setCurrentOpenMenu] = useState<string | null>(null);
+  return (
+    <SuggestionContext.Provider value={{ getProviders, currentOpenMenu, setCurrentOpenMenu }}>
+      {children}
+    </SuggestionContext.Provider>
+  );
+};
 
 describe('PasswordField', () => {
   const mockSuggestionProvider = {
@@ -19,7 +35,7 @@ describe('PasswordField', () => {
 
   const renderWithSuggestions = (children: React.ReactNode) => {
     return render(
-      <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>{children}</SuggestionContext.Provider>,
+      <StatefulSuggestionProvider getProviders={getProvidersMock}>{children}</StatefulSuggestionProvider>,
     );
   };
 

--- a/src/form/fields/PasswordField.tsx
+++ b/src/form/fields/PasswordField.tsx
@@ -8,6 +8,7 @@ import { SchemaContext } from '../providers/SchemaProvider';
 import { isDefined, isRawString } from '../utils';
 import { FieldActions } from './FieldActions';
 import { FieldWrapper } from './FieldWrapper';
+import { SuggestionsButton } from './SuggestionsButton';
 
 export const PasswordField: FunctionComponent<FieldProps> = ({ propName, required, onRemove: onRemoveProps }) => {
   const { schema } = useContext(SchemaContext);
@@ -51,7 +52,7 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
     [onFieldChange],
   );
 
-  const { suggestionsMenu } = useSuggestions({
+  const { suggestionsMenu, openSuggestions } = useSuggestions({
     propName,
     schema,
     inputRef,
@@ -89,6 +90,8 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
         {suggestionsMenu}
 
         <TextInputGroupUtilities>
+          <SuggestionsButton propName={propName} onClick={openSuggestions} />
+
           <Button
             variant="plain"
             data-testid={`${propName}__toggle-visibility`}

--- a/src/form/fields/PasswordField.tsx
+++ b/src/form/fields/PasswordField.tsx
@@ -51,7 +51,7 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
     [onFieldChange],
   );
 
-  const suggestions = useSuggestions({
+  const { suggestionsMenu } = useSuggestions({
     propName,
     schema,
     inputRef,
@@ -86,7 +86,7 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
           ref={inputRef}
         />
 
-        {suggestions}
+        {suggestionsMenu}
 
         <TextInputGroupUtilities>
           <Button

--- a/src/form/fields/StringField.test.tsx
+++ b/src/form/fields/StringField.test.tsx
@@ -1,10 +1,26 @@
 import { act, fireEvent, render, waitFor, within } from '@testing-library/react';
 import { JSONSchema4 } from 'json-schema';
+import { ReactNode, useState } from 'react';
 import { SuggestionContext } from '../providers';
 import { ModelContext, ModelContextProvider } from '../providers/ModelProvider';
 import { SchemaProvider } from '../providers/SchemaProvider';
 import { ROOT_PATH } from '../utils';
 import { StringField } from './StringField';
+
+const StatefulSuggestionProvider = ({
+  children,
+  getProviders,
+}: {
+  children: ReactNode;
+  getProviders: jest.Mock;
+}) => {
+  const [currentOpenMenu, setCurrentOpenMenu] = useState<string | null>(null);
+  return (
+    <SuggestionContext.Provider value={{ getProviders, currentOpenMenu, setCurrentOpenMenu }}>
+      {children}
+    </SuggestionContext.Provider>
+  );
+};
 
 describe('StringField', () => {
   const mockSuggestionProvider = {
@@ -20,7 +36,7 @@ describe('StringField', () => {
 
   const renderWithSuggestions = (children: React.ReactNode) => {
     return render(
-      <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>{children}</SuggestionContext.Provider>,
+      <StatefulSuggestionProvider getProviders={getProvidersMock}>{children}</StatefulSuggestionProvider>,
     );
   };
 

--- a/src/form/fields/StringField.tsx
+++ b/src/form/fields/StringField.tsx
@@ -12,6 +12,7 @@ import { SchemaContext } from '../providers/SchemaProvider';
 import { isDefined, isRawString } from '../utils';
 import { FieldActions } from './FieldActions';
 import { FieldWrapper } from './FieldWrapper';
+import { SuggestionsButton } from './SuggestionsButton';
 
 interface StringFieldProps extends FieldProps {
   fieldType?: TextInputGroupMainProps['type'];
@@ -82,7 +83,7 @@ export const StringField: FunctionComponent<StringFieldProps> = ({
     [onFieldChange],
   );
 
-  const { suggestionsMenu } = useSuggestions({
+  const { suggestionsMenu, openSuggestions } = useSuggestions({
     propName,
     schema,
     inputRef,
@@ -122,6 +123,8 @@ export const StringField: FunctionComponent<StringFieldProps> = ({
 
         <TextInputGroupUtilities>
           {additionalUtility}
+
+          <SuggestionsButton propName={propName} onClick={openSuggestions} />
 
           <FieldActions
             propName={propName}

--- a/src/form/fields/StringField.tsx
+++ b/src/form/fields/StringField.tsx
@@ -82,7 +82,7 @@ export const StringField: FunctionComponent<StringFieldProps> = ({
     [onFieldChange],
   );
 
-  const suggestions = useSuggestions({
+  const { suggestionsMenu } = useSuggestions({
     propName,
     schema,
     inputRef,
@@ -118,7 +118,7 @@ export const StringField: FunctionComponent<StringFieldProps> = ({
           ref={inputRef}
         />
 
-        {suggestions}
+        {suggestionsMenu}
 
         <TextInputGroupUtilities>
           {additionalUtility}

--- a/src/form/fields/SuggestionsButton.tsx
+++ b/src/form/fields/SuggestionsButton.tsx
@@ -1,0 +1,20 @@
+import { Button } from '@patternfly/react-core';
+import { LightbulbIcon } from '@patternfly/react-icons';
+import { FunctionComponent } from 'react';
+
+interface SuggestionsButtonProps {
+  propName: string;
+  onClick: () => void;
+}
+
+export const SuggestionsButton: FunctionComponent<SuggestionsButtonProps> = ({ propName, onClick }) => (
+  <Button
+    variant="plain"
+    className="kaoto-form__suggestions-button"
+    data-testid={`${propName}__open-suggestions-button`}
+    onClick={onClick}
+    aria-label="Open suggestions"
+    title="Open suggestions (Ctrl+Space)"
+    icon={<LightbulbIcon />}
+  />
+);

--- a/src/form/fields/TextAreaField.test.tsx
+++ b/src/form/fields/TextAreaField.test.tsx
@@ -6,7 +6,10 @@ import { TextAreaField } from './TextAreaField';
 
 // Mock useSuggestions to control its output
 jest.mock('../hooks/suggestions', () => ({
-  useSuggestions: jest.fn(() => null),
+  useSuggestions: jest.fn(() => ({
+    suggestionsMenu: null,
+    openSuggestions: jest.fn(),
+  })),
 }));
 
 describe('TextAreaField', () => {
@@ -117,7 +120,10 @@ describe('TextAreaField', () => {
     const SuggestionsMenu = () => <div data-testid="suggestions-menu">Suggestions</div>;
     const { useSuggestions } = jest.requireMock('../hooks/suggestions');
 
-    useSuggestions.mockImplementation(() => <SuggestionsMenu />);
+    useSuggestions.mockImplementation(() => ({
+      suggestionsMenu: <SuggestionsMenu />,
+      openSuggestions: jest.fn(),
+    }));
 
     const { getByRole, getByTestId } = render(
       <ModelContextProvider model="Value" onPropertyChange={jest.fn()}>

--- a/src/form/fields/TextAreaField.tsx
+++ b/src/form/fields/TextAreaField.tsx
@@ -30,7 +30,7 @@ export const TextAreaField: FunctionComponent<FieldProps> = ({ propName, require
     onChange(undefined as unknown as string);
   };
 
-  const suggestions = useSuggestions({
+  const { suggestionsMenu } = useSuggestions({
     propName,
     schema,
     inputRef: textAreaRef,
@@ -65,7 +65,7 @@ export const TextAreaField: FunctionComponent<FieldProps> = ({ propName, require
             ref={textAreaRef}
           />
 
-          {suggestions}
+          {suggestionsMenu}
         </InputGroupItem>
 
         <InputGroupItem>

--- a/src/form/fields/TextAreaField.tsx
+++ b/src/form/fields/TextAreaField.tsx
@@ -7,6 +7,7 @@ import { FieldProps } from '../models/typings';
 import { SchemaContext } from '../providers/SchemaProvider';
 import { isDefined } from '../utils';
 import { FieldWrapper } from './FieldWrapper';
+import { SuggestionsButton } from './SuggestionsButton';
 
 export const TextAreaField: FunctionComponent<FieldProps> = ({ propName, required, onRemove: onRemoveProps }) => {
   const { schema } = useContext(SchemaContext);
@@ -30,7 +31,7 @@ export const TextAreaField: FunctionComponent<FieldProps> = ({ propName, require
     onChange(undefined as unknown as string);
   };
 
-  const { suggestionsMenu } = useSuggestions({
+  const { suggestionsMenu, openSuggestions } = useSuggestions({
     propName,
     schema,
     inputRef: textAreaRef,
@@ -69,6 +70,8 @@ export const TextAreaField: FunctionComponent<FieldProps> = ({ propName, require
         </InputGroupItem>
 
         <InputGroupItem>
+          <SuggestionsButton propName={propName} onClick={openSuggestions} />
+
           <Button
             variant="plain"
             data-testid={`${propName}__clear`}

--- a/src/form/fields/__snapshots__/PasswordField.test.tsx.snap
+++ b/src/form/fields/__snapshots__/PasswordField.test.tsx.snap
@@ -85,9 +85,37 @@ exports[`PasswordField should render 1`] = `
           class="pf-v6-c-text-input-group__utilities"
         >
           <button
+            aria-label="Open suggestions"
+            class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+            data-ouia-component-id="OUIA-Generated-Button-plain-2"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            data-testid="#__open-suggestions-button"
+            title="Open suggestions (Ctrl+Space)"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                />
+              </svg>
+            </span>
+          </button>
+          <button
             aria-label="Show # value"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-2"
+            data-ouia-component-id="OUIA-Generated-Button-plain-3"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             data-testid="#__toggle-visibility"

--- a/src/form/fields/__snapshots__/StringField.test.tsx.snap
+++ b/src/form/fields/__snapshots__/StringField.test.tsx.snap
@@ -85,6 +85,34 @@ exports[`StringField should render 1`] = `
           class="pf-v6-c-text-input-group__utilities"
         >
           <button
+            aria-label="Open suggestions"
+            class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+            data-ouia-component-id="OUIA-Generated-Button-plain-2"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            data-testid="#__open-suggestions-button"
+            title="Open suggestions (Ctrl+Space)"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                />
+              </svg>
+            </span>
+          </button>
+          <button
             aria-expanded="false"
             aria-label="#__field-actions"
             class="pf-v6-c-menu-toggle pf-m-plain"

--- a/src/form/fields/__snapshots__/TextAreaField.test.tsx.snap
+++ b/src/form/fields/__snapshots__/TextAreaField.test.tsx.snap
@@ -86,9 +86,37 @@ exports[`TextAreaField should render 1`] = `
           class="pf-v6-c-input-group__item"
         >
           <button
+            aria-label="Open suggestions"
+            class="pf-v6-c-button pf-m-plain kaoto-form__suggestions-button"
+            data-ouia-component-id="OUIA-Generated-Button-plain-2"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            data-testid="#__open-suggestions-button"
+            title="Open suggestions (Ctrl+Space)"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"
+                />
+              </svg>
+            </span>
+          </button>
+          <button
             aria-label="Clear # field"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-2"
+            data-ouia-component-id="OUIA-Generated-Button-plain-3"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             data-testid="#__clear"

--- a/src/form/hooks/suggestions.test.tsx
+++ b/src/form/hooks/suggestions.test.tsx
@@ -4,6 +4,21 @@ import { SuggestionProvider } from '../models/suggestions';
 import { SuggestionContext } from '../providers';
 import { useSuggestions } from './suggestions';
 
+const StatefulSuggestionProvider = ({
+  children,
+  getProviders,
+}: {
+  children: ReactNode;
+  getProviders: jest.Mock;
+}) => {
+  const [currentOpenMenu, setCurrentOpenMenu] = useState<string | null>(null);
+  return (
+    <SuggestionContext.Provider value={{ getProviders, currentOpenMenu, setCurrentOpenMenu }}>
+      {children}
+    </SuggestionContext.Provider>
+  );
+};
+
 describe('useSuggestions', () => {
   let setValueMock: jest.Mock;
   let mockProvider: SuggestionProvider;
@@ -13,7 +28,7 @@ describe('useSuggestions', () => {
     const inputRef = useRef<HTMLInputElement>(null);
     const [value, setValue] = useState<string | number>('');
 
-    const suggestions = useSuggestions({
+    const { suggestionsMenu } = useSuggestions({
       propName: 'testProp',
       schema: { type: 'string' },
       value,
@@ -38,7 +53,7 @@ describe('useSuggestions', () => {
           aria-label="Test input"
         />
 
-        {suggestions}
+        {suggestionsMenu}
 
         <button type="button">Secondary focus</button>
       </>
@@ -47,7 +62,7 @@ describe('useSuggestions', () => {
 
   const renderWithContext = (children: ReactNode) => {
     return render(
-      <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>{children}</SuggestionContext.Provider>,
+      <StatefulSuggestionProvider getProviders={getProvidersMock}>{children}</StatefulSuggestionProvider>,
     );
   };
 
@@ -75,35 +90,29 @@ describe('useSuggestions', () => {
     const inputElement = document.createElement('input');
     const inputRef = { current: inputElement };
 
-    let result: ReactNode;
-
-    await act(async () => {
-      const hookResult = renderHook(
-        () =>
-          useSuggestions({
-            inputRef,
-            propName: 'testProp',
-            schema: { type: 'string' },
-            value: '',
-            setValue: setValueMock,
-          }),
-        {
-          wrapper: ({ children }) => (
-            <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>
-              {children}
-            </SuggestionContext.Provider>
-          ),
-        },
-      );
-
-      result = hookResult.result.current;
-    });
+    const { result } = renderHook(
+      () =>
+        useSuggestions({
+          inputRef,
+          propName: 'testProp',
+          schema: { type: 'string' },
+          value: '',
+          setValue: setValueMock,
+        }),
+      {
+        wrapper: ({ children }) => (
+          <SuggestionContext.Provider value={{ getProviders: getProvidersMock, currentOpenMenu: null, setCurrentOpenMenu: jest.fn() }}>
+            {children}
+          </SuggestionContext.Provider>
+        ),
+      },
+    );
 
     await waitFor(() => {
       expect(mockProvider.getSuggestions).not.toHaveBeenCalled();
     });
 
-    expect(result).toBeDefined();
+    expect(result.current.suggestionsMenu).toBeDefined();
   });
 
   it('should handle setValue being undefined', () => {
@@ -116,7 +125,7 @@ describe('useSuggestions', () => {
 
     const { result } = renderHook(() => useSuggestions(propsWithoutSetValue), {
       wrapper: ({ children }) => (
-        <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>{children}</SuggestionContext.Provider>
+        <SuggestionContext.Provider value={{ getProviders: getProvidersMock, currentOpenMenu: null, setCurrentOpenMenu: jest.fn() }}>{children}</SuggestionContext.Provider>
       ),
     });
 
@@ -139,7 +148,7 @@ describe('useSuggestions', () => {
           }),
         {
           wrapper: ({ children }) => (
-            <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>
+            <SuggestionContext.Provider value={{ getProviders: getProvidersMock, currentOpenMenu: null, setCurrentOpenMenu: jest.fn() }}>
               {children}
             </SuggestionContext.Provider>
           ),
@@ -175,7 +184,7 @@ describe('useSuggestions', () => {
           }),
         {
           wrapper: ({ children }) => (
-            <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>
+            <SuggestionContext.Provider value={{ getProviders: getProvidersMock, currentOpenMenu: null, setCurrentOpenMenu: jest.fn() }}>
               {children}
             </SuggestionContext.Provider>
           ),
@@ -205,7 +214,7 @@ describe('useSuggestions', () => {
 
     const { rerender } = renderHook(() => useSuggestions(props), {
       wrapper: ({ children }) => (
-        <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>{children}</SuggestionContext.Provider>
+        <SuggestionContext.Provider value={{ getProviders: getProvidersMock, currentOpenMenu: null, setCurrentOpenMenu: jest.fn() }}>{children}</SuggestionContext.Provider>
       ),
     });
 

--- a/src/form/hooks/suggestions.tsx
+++ b/src/form/hooks/suggestions.tsx
@@ -1,6 +1,6 @@
 import { Menu, MenuContent, MenuItem, MenuList, Popper, SearchInput } from '@patternfly/react-core';
 import { JSONSchema4 } from 'json-schema';
-import { ReactNode, RefObject, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { ReactNode, RefObject, useCallback, useContext, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { GroupedSuggestions, Suggestion, SuggestionProvider } from '../models/suggestions';
 import { SuggestionContext } from '../providers';
 import { applySuggestion } from '../utils/apply-suggestion';
@@ -13,14 +13,28 @@ type UseSuggestionsProps = {
   value: string | number;
   setValue?: (value: string) => void;
 };
-export const useSuggestions = ({ propName, schema, inputRef, value, setValue }: UseSuggestionsProps): ReactNode => {
-  const [isVisible, setIsVisible] = useState(false);
+
+type UseSuggestionsReturn = {
+  suggestionsMenu: ReactNode;
+  openSuggestions: () => void;
+};
+
+export const useSuggestions = ({
+  propName,
+  schema,
+  inputRef,
+  value,
+  setValue,
+}: UseSuggestionsProps): UseSuggestionsReturn => {
+  const menuId = `${propName}-${useId()}`;
   const [searchValue, setSearchValue] = useState('');
   const [groupedSuggestions, setGroupedSuggestions] = useState<GroupedSuggestions>({ root: [] });
   const menuRef = useRef<HTMLDivElement>(null);
   const firstElementRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const { getProviders } = useContext(SuggestionContext);
+  const { getProviders, currentOpenMenu, setCurrentOpenMenu } = useContext(SuggestionContext);
+
+  const isVisible = currentOpenMenu === menuId;
 
   const suggestionProviders: SuggestionProvider[] = useMemo(
     () => getProviders(propName, schema),
@@ -30,22 +44,22 @@ export const useSuggestions = ({ propName, schema, inputRef, value, setValue }: 
   const onEscapeKey = useCallback(
     (event: React.KeyboardEvent | KeyboardEvent) => {
       event.preventDefault();
-      setIsVisible(false);
+      setCurrentOpenMenu(null);
       requestAnimationFrame(() => {
         inputRef.current?.focus();
       });
     },
-    [inputRef],
+    [inputRef, setCurrentOpenMenu],
   );
 
   const handleInputKeyDown = useCallback(
     (event: Event) => {
       if (!(event instanceof KeyboardEvent)) return;
 
-if ((event.ctrlKey && event.code === 'Space') || (event.altKey && event.code === 'Escape')) {
+      if ((event.ctrlKey && event.code === 'Space') || (event.altKey && event.code === 'Escape')) {
         event.preventDefault();
         setSearchValue('');
-        setIsVisible(true);
+        setCurrentOpenMenu(menuId);
         requestAnimationFrame(() => {
           firstElementRef.current?.focus();
           firstElementRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
@@ -54,20 +68,20 @@ if ((event.ctrlKey && event.code === 'Space') || (event.altKey && event.code ===
         onEscapeKey(event);
       }
     },
-    [onEscapeKey],
+    [onEscapeKey, setCurrentOpenMenu, menuId],
   );
 
   const getHandleOnClick = useCallback(
     (inputValue: string | number, suggestion: Suggestion) => () => {
       const { newValue, cursorPosition } = applySuggestion(suggestion, inputValue, inputRef.current?.selectionStart);
 
-      setIsVisible(false);
+      setCurrentOpenMenu(null);
       setValue?.(newValue);
 
       inputRef.current?.focus();
       inputRef.current?.setSelectionRange(cursorPosition, cursorPosition);
     },
-    [inputRef, setValue],
+    [inputRef, setValue, setCurrentOpenMenu],
   );
 
   const getHandleMenuKeyDown = useCallback(
@@ -129,6 +143,28 @@ if ((event.ctrlKey && event.code === 'Space') || (event.altKey && event.code ===
     };
   }, [suggestionProviders, value, propName, inputRef, isVisible, searchValue]);
 
+  const focusOnSearchInput = useCallback(() => {
+    searchInputRef.current?.focus();
+  }, []);
+
+  const handleOnSearchChange = useCallback((_event: unknown, value: string) => {
+    setSearchValue(value);
+  }, []);
+
+  const openSuggestions = useCallback(() => {
+    setSearchValue('');
+    setCurrentOpenMenu((prev) => {
+      const newValue = prev === menuId ? null : menuId;
+      if (newValue) {
+        requestAnimationFrame(() => {
+          firstElementRef.current?.focus();
+          firstElementRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+        });
+      }
+      return newValue;
+    });
+  }, [menuId, setCurrentOpenMenu]);
+
   /** Register keyboard bindings */
   useEffect(() => {
     const input = inputRef.current;
@@ -156,15 +192,7 @@ if ((event.ctrlKey && event.code === 'Space') || (event.altKey && event.code ===
     };
   }, [handleInputKeyDown, inputRef]);
 
-  const focusOnSearchInput = useCallback(() => {
-    searchInputRef.current?.focus();
-  }, []);
-
-  const handleOnSearchChange = useCallback((_event: unknown, value: string) => {
-    setSearchValue(value);
-  }, []);
-
-  return (
+  const suggestionsMenu = (
     <Popper
       preventOverflow
       maxWidth="trigger"
@@ -245,4 +273,9 @@ if ((event.ctrlKey && event.code === 'Space') || (event.altKey && event.code ===
       }
     />
   );
+
+  return {
+    suggestionsMenu,
+    openSuggestions,
+  };
 };

--- a/src/form/hooks/suggestions.tsx
+++ b/src/form/hooks/suggestions.tsx
@@ -152,6 +152,9 @@ export const useSuggestions = ({
   }, []);
 
   const openSuggestions = useCallback(() => {
+    const input = inputRef.current;
+    if (input?.disabled || input?.readOnly) return;
+
     setSearchValue('');
     setCurrentOpenMenu((prev) => {
       const newValue = prev === menuId ? null : menuId;
@@ -163,9 +166,9 @@ export const useSuggestions = ({
       }
       return newValue;
     });
-  }, [menuId, setCurrentOpenMenu]);
+  }, [menuId, setCurrentOpenMenu, inputRef]);
 
-  /** Register keyboard bindings */
+  /** Register keyboard bindings and double-click handler */
   useEffect(() => {
     const input = inputRef.current;
     if (!input) return;
@@ -179,6 +182,7 @@ export const useSuggestions = ({
 
     input.addEventListener('focus', handleFocus);
     input.addEventListener('blur', handleBlur);
+    input.addEventListener('dblclick', openSuggestions);
 
     // If already focused, register immediately
     if (document.activeElement === input) {
@@ -189,8 +193,9 @@ export const useSuggestions = ({
       input.removeEventListener('focus', handleFocus);
       input.removeEventListener('blur', handleBlur);
       input.removeEventListener('keydown', handleInputKeyDown);
+      input.removeEventListener('dblclick', openSuggestions);
     };
-  }, [handleInputKeyDown, inputRef]);
+  }, [handleInputKeyDown, inputRef, openSuggestions]);
 
   const suggestionsMenu = (
     <Popper

--- a/src/form/providers/SuggestionRegistryProvider.tsx
+++ b/src/form/providers/SuggestionRegistryProvider.tsx
@@ -6,17 +6,24 @@ interface SuggestionContextApi {
   registerProvider: (provider: SuggestionProvider) => void;
   unregisterProvider: (id: string) => void;
 }
+type MenuStateSetter = (menuId: string | null | ((prev: string | null) => string | null)) => void;
+
 interface SuggestionContext {
   getProviders: (propertyName: string, schema: JSONSchema4) => SuggestionProvider[];
+  currentOpenMenu: string | null;
+  setCurrentOpenMenu: MenuStateSetter;
 }
 
 export const SuggestionContextApi = createContext<SuggestionContextApi | undefined | null>(undefined);
 export const SuggestionContext = createContext<SuggestionContext>({
   getProviders: () => [],
+  currentOpenMenu: null,
+  setCurrentOpenMenu: () => {},
 });
 
 export const SuggestionRegistryProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
   const [providers, setProviders] = useState<SuggestionProvider[]>([]);
+  const [currentOpenMenu, setCurrentOpenMenu] = useState<string | null>(null);
 
   const registerProvider = useCallback((provider: SuggestionProvider) => {
     setProviders((prevProviders) => {
@@ -48,9 +55,18 @@ export const SuggestionRegistryProvider: FunctionComponent<PropsWithChildren> = 
     [registerProvider, unregisterProvider],
   );
 
+  const contextValue = useMemo(
+    () => ({
+      getProviders,
+      currentOpenMenu,
+      setCurrentOpenMenu,
+    }),
+    [getProviders, currentOpenMenu],
+  );
+
   return (
     <SuggestionContextApi.Provider value={contextApi}>
-      <SuggestionContext.Provider value={{ getProviders }}>{children}</SuggestionContext.Provider>
+      <SuggestionContext.Provider value={contextValue}>{children}</SuggestionContext.Provider>
     </SuggestionContextApi.Provider>
   );
 };


### PR DESCRIPTION
- Centralize suggestion menu visibility state in SuggestionContext so only one suggestion menu can be open at a time across all fields

- Add a lightbulb button to StringField, PasswordField, and TextAreaField that opens the suggestions menu on click (visible on hover/focus)

- Add double-click handler on input fields as an alternative way to open suggestions

- Change useSuggestions return type from ReactNode to { suggestionsMenu, openSuggestions } to support the new interaction methods

<img width="814" height="610" alt="Screenshot 2026-03-17 at 16 34 41" src="https://github.com/user-attachments/assets/753e410b-9f0b-4d63-8b89-16e9c1514689" />



https://github.com/user-attachments/assets/ad5a3386-756b-4cb1-b121-40edecf3880c





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lightbulb suggestions button (appears on hover/focus) for password, text, textarea, and key-value fields.
  * Suggestions can be opened by clicking the button, double-clicking the input, or via keyboard, providing faster access to suggested values.
  * Improved accessibility and focus behavior for suggestion interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->