### PR TITLE
fix(Suggestions): Focus search input when opening suggestions menu

### DIFF
--- a/src/form/hooks/suggestions.tsx
+++ b/src/form/hooks/suggestions.tsx
@@ -61,8 +61,7 @@ export const useSuggestions = ({
         setSearchValue('');
         setCurrentOpenMenu(menuId);
         requestAnimationFrame(() => {
-          firstElementRef.current?.focus();
-          firstElementRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+          searchInputRef.current?.focus();
         });
       } else if (event.key === 'Escape') {
         onEscapeKey(event);
@@ -160,8 +159,7 @@ export const useSuggestions = ({
       const newValue = prev === menuId ? null : menuId;
       if (newValue) {
         requestAnimationFrame(() => {
-          firstElementRef.current?.focus();
-          firstElementRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+          searchInputRef.current?.focus();
         });
       }
       return newValue;


### PR DESCRIPTION

https://github.com/user-attachments/assets/106bd8f0-6401-41b8-b2e1-c1b3ccf88c7d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in suggestions dropdown—focus now remains on the search input when opening via keyboard shortcuts (Ctrl+Space, Alt+Escape) or toggling suggestions, allowing for continuous typing without focus shifts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->