### PR TITLE
feat(Suggestions): Add suggestion button and centralized menu state

### DIFF
--- a/src/form/KeyValue/KeyValueField.test.tsx
+++ b/src/form/KeyValue/KeyValueField.test.tsx
@@ -1,15 +1,29 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { ReactNode, useState } from 'react';
+import { SuggestionContext } from '../providers/SuggestionRegistryProvider';
 import { KeyValueField } from './KeyValueField';
 
-// Mock useSuggestions to control its output
-jest.mock('../hooks/suggestions', () => ({
-  useSuggestions: jest.fn(() => ({
-    suggestionsMenu: null,
-    openSuggestions: jest.fn(),
-  })),
-}));
+const StatefulSuggestionProvider = ({ children, getProviders }: { children: ReactNode; getProviders: jest.Mock }) => {
+  const [currentOpenMenu, setCurrentOpenMenu] = useState<string | null>(null);
+  return (
+    <SuggestionContext.Provider value={{ getProviders, currentOpenMenu, setCurrentOpenMenu }}>
+      {children}
+    </SuggestionContext.Provider>
+  );
+};
 
 describe('KeyValueField', () => {
+  const mockSuggestionProvider = {
+    id: 'test-provider',
+    appliesTo: jest.fn().mockReturnValue(true),
+    getSuggestions: jest.fn().mockResolvedValue([
+      { value: 'test-suggestion-1', description: 'First test suggestion' },
+      { value: 'test-suggestion-2', description: 'Second test suggestion' },
+    ]),
+  };
+
+  const getProvidersMock = jest.fn().mockReturnValue([mockSuggestionProvider]);
+
   const defaultProps = {
     id: 'test-id',
     name: 'test-name',
@@ -19,6 +33,10 @@ describe('KeyValueField', () => {
     onChange: jest.fn(),
     onFocus: jest.fn(),
     onBlur: jest.fn(),
+  };
+
+  const renderWithSuggestions = (children: React.ReactNode) => {
+    return render(<StatefulSuggestionProvider getProviders={getProvidersMock}>{children}</StatefulSuggestionProvider>);
   };
 
   beforeEach(() => {
@@ -75,15 +93,7 @@ describe('KeyValueField', () => {
   });
 
   it('shows suggestions when Ctrl+Space is pressed', async () => {
-    const SuggestionsMenu = () => <div data-testid="suggestions-menu">Suggestions</div>;
-    const { useSuggestions } = jest.requireMock('../hooks/suggestions');
-
-    useSuggestions.mockImplementation(() => ({
-      suggestionsMenu: <SuggestionsMenu />,
-      openSuggestions: jest.fn(),
-    }));
-
-    const { getByTestId } = render(<KeyValueField {...defaultProps} />);
+    const { getByTestId, getByRole } = renderWithSuggestions(<KeyValueField {...defaultProps} />);
     const input = getByTestId('keyvalue-input');
 
     await act(async () => {
@@ -94,5 +104,8 @@ describe('KeyValueField', () => {
     await waitFor(() => {
       expect(getByTestId('suggestions-menu')).toBeInTheDocument();
     });
+
+    expect(getByRole('menuitem', { name: 'test-suggestion-1' })).toBeInTheDocument();
+    expect(getByRole('menuitem', { name: 'test-suggestion-2' })).toBeInTheDocument();
   });
 });

--- a/src/form/KeyValue/KeyValueField.test.tsx
+++ b/src/form/KeyValue/KeyValueField.test.tsx
@@ -3,7 +3,10 @@ import { KeyValueField } from './KeyValueField';
 
 // Mock useSuggestions to control its output
 jest.mock('../hooks/suggestions', () => ({
-  useSuggestions: jest.fn(() => null),
+  useSuggestions: jest.fn(() => ({
+    suggestionsMenu: null,
+    openSuggestions: jest.fn(),
+  })),
 }));
 
 describe('KeyValueField', () => {
@@ -75,7 +78,10 @@ describe('KeyValueField', () => {
     const SuggestionsMenu = () => <div data-testid="suggestions-menu">Suggestions</div>;
     const { useSuggestions } = jest.requireMock('../hooks/suggestions');
 
-    useSuggestions.mockImplementation(() => <SuggestionsMenu />);
+    useSuggestions.mockImplementation(() => ({
+      suggestionsMenu: <SuggestionsMenu />,
+      openSuggestions: jest.fn(),
+    }));
 
     const { getByTestId } = render(<KeyValueField {...defaultProps} />);
     const input = getByTestId('keyvalue-input');

--- a/src/form/KeyValue/KeyValueField.tsx
+++ b/src/form/KeyValue/KeyValueField.tsx
@@ -22,7 +22,7 @@ export const KeyValueField = forwardRef<HTMLInputElement, KeyValueFieldProps>(
 
     useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
 
-    const suggestions = useSuggestions({
+    const { suggestionsMenu } = useSuggestions({
       propName: name,
       schema: STRING_SCHEMA,
       inputRef,
@@ -49,7 +49,7 @@ export const KeyValueField = forwardRef<HTMLInputElement, KeyValueFieldProps>(
           placeholder={placeholder}
           value={value}
         />
-        {suggestions}
+        {suggestionsMenu}
       </div>
     );
   },

--- a/src/form/__snapshots__/KaotoForm.test.tsx.snap
+++ b/src/form/__snapshots__/KaotoForm.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`KaotoForm should validate the model 1`] = `
           class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--auto-align cds--autoalign cds--popover--bottom cds--toggletip cds--autoalign"
         >
           <button
-            aria-controls="id-_r_14_"
+            aria-controls="id-_r_1b_"
             aria-expanded="false"
             aria-label="More info for Name field"
             class="cds--toggletip-button"
@@ -63,7 +63,7 @@ exports[`KaotoForm should validate the model 1`] = `
           </button>
           <span
             class="cds--popover"
-            id="id-_r_14_"
+            id="id-_r_1b_"
           >
             <span
               class="cds--popover-content"
@@ -148,7 +148,7 @@ exports[`KaotoForm should validate the model 1`] = `
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                aria-labelledby="tooltip-_r_17_"
+                aria-labelledby="tooltip-_r_1e_"
                 class="cds--overflow-menu cds--overflow-menu--sm cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--icon-only"
                 data-testid="#.name__field-actions"
                 type="button"
@@ -186,7 +186,7 @@ exports[`KaotoForm should validate the model 1`] = `
             <span
               aria-hidden="true"
               class="cds--popover"
-              id="tooltip-_r_17_"
+              id="tooltip-_r_1e_"
               role="tooltip"
             >
               <span

--- a/src/form/__snapshots__/KaotoForm.test.tsx.snap
+++ b/src/form/__snapshots__/KaotoForm.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`KaotoForm should validate the model 1`] = `
           class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--auto-align cds--autoalign cds--popover--bottom cds--toggletip cds--autoalign"
         >
           <button
-            aria-controls="id-_r_1b_"
+            aria-controls="id-_r_23_"
             aria-expanded="false"
             aria-label="More info for Name field"
             class="cds--toggletip-button"
@@ -63,7 +63,7 @@ exports[`KaotoForm should validate the model 1`] = `
           </button>
           <span
             class="cds--popover"
-            id="id-_r_1b_"
+            id="id-_r_23_"
           >
             <span
               class="cds--popover-content"
@@ -86,6 +86,56 @@ exports[`KaotoForm should validate the model 1`] = `
                 class="cds--popover-caret cds--popover--auto-align"
               />
             </span>
+          </span>
+        </span>
+        <span
+          class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--top cds--tooltip cds--icon-tooltip"
+        >
+          <div
+            class="cds--tooltip-trigger__wrapper"
+          >
+            <button
+              aria-labelledby="tooltip-_r_26_"
+              class="cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--icon-only"
+              data-testid="#.name__open-suggestions-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                focusable="false"
+                height="16"
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M11 24H21V26H11z"
+                />
+                <path
+                  d="M13 28H19V30H13z"
+                />
+                <path
+                  d="M16,2A10,10,0,0,0,6,12a9.19,9.19,0,0,0,3.46,7.62c1,.93,1.54,1.46,1.54,2.38h2c0-1.84-1.11-2.87-2.19-3.86A7.2,7.2,0,0,1,8,12a8,8,0,0,1,16,0,7.2,7.2,0,0,1-2.82,6.14c-1.07,1-2.18,2-2.18,3.86h2c0-.92.53-1.45,1.54-2.39A9.18,9.18,0,0,0,26,12,10,10,0,0,0,16,2Z"
+                />
+              </svg>
+            </button>
+          </div>
+          <span
+            aria-hidden="true"
+            class="cds--popover"
+            id="tooltip-_r_26_"
+            role="tooltip"
+          >
+            <span
+              class="cds--popover-content cds--tooltip-content"
+            >
+              Open suggestions (Ctrl+Space)
+            </span>
+            <span
+              class="cds--popover-caret"
+            />
           </span>
         </span>
       </div>
@@ -148,7 +198,7 @@ exports[`KaotoForm should validate the model 1`] = `
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                aria-labelledby="tooltip-_r_1e_"
+                aria-labelledby="tooltip-_r_2a_"
                 class="cds--overflow-menu cds--overflow-menu--sm cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--icon-only"
                 data-testid="#.name__field-actions"
                 type="button"
@@ -186,7 +236,7 @@ exports[`KaotoForm should validate the model 1`] = `
             <span
               aria-hidden="true"
               class="cds--popover"
-              id="tooltip-_r_1e_"
+              id="tooltip-_r_2a_"
               role="tooltip"
             >
               <span

--- a/src/form/fields/FieldWrapper.tsx
+++ b/src/form/fields/FieldWrapper.tsx
@@ -1,5 +1,5 @@
-import { Stack, Toggletip, ToggletipButton, ToggletipContent, Tag } from '@carbon/react';
-import { Information, WarningFilled } from '@carbon/icons-react';
+import { IconButton, Stack, Toggletip, ToggletipButton, ToggletipContent, Tag } from '@carbon/react';
+import { Idea, Information, WarningFilled } from '@carbon/icons-react';
 import { FunctionComponent, PropsWithChildren, ReactNode } from 'react';
 import { FieldProps } from '../models/typings';
 import clsx from 'clsx';
@@ -13,6 +13,7 @@ interface FieldWrapperProps extends FieldProps {
   errors?: string[];
   isRow?: boolean;
   isRaw?: boolean;
+  onOpenSuggestions?: () => void;
 }
 
 export const FieldWrapper: FunctionComponent<PropsWithChildren<FieldWrapperProps>> = ({
@@ -26,6 +27,7 @@ export const FieldWrapper: FunctionComponent<PropsWithChildren<FieldWrapperProps
   isRow = false,
   children,
   isRaw = false,
+  onOpenSuggestions,
 }) => {
   const id = `${propName}-popover`;
   const label = title ?? propName.split('.').pop();
@@ -52,6 +54,11 @@ export const FieldWrapper: FunctionComponent<PropsWithChildren<FieldWrapperProps
             <p>Default: {defaultValue}</p>
           </ToggletipContent>
         </Toggletip>
+        {onOpenSuggestions && (
+          <IconButton kind="ghost" size="sm" label="Open suggestions (Ctrl+Space)" onClick={onOpenSuggestions} data-testid={`${propName}__open-suggestions-button`}>
+            <Idea />
+          </IconButton>
+        )}
       </div>
 
       {children}

--- a/src/form/fields/PasswordField.test.tsx
+++ b/src/form/fields/PasswordField.test.tsx
@@ -1,9 +1,25 @@
 import { act, fireEvent, render, waitFor, within } from '@testing-library/react';
+import { ReactNode, useState } from 'react';
 import { ModelContextProvider } from '../providers/ModelProvider';
 import { SchemaProvider } from '../providers/SchemaProvider';
 import { SuggestionContext } from '../providers/SuggestionRegistryProvider';
 import { ROOT_PATH } from '../utils';
 import { PasswordField } from './PasswordField';
+
+const StatefulSuggestionProvider = ({
+  children,
+  getProviders,
+}: {
+  children: ReactNode;
+  getProviders: jest.Mock;
+}) => {
+  const [currentOpenMenu, setCurrentOpenMenu] = useState<string | null>(null);
+  return (
+    <SuggestionContext.Provider value={{ getProviders, currentOpenMenu, setCurrentOpenMenu }}>
+      {children}
+    </SuggestionContext.Provider>
+  );
+};
 
 describe('PasswordField', () => {
   const mockSuggestionProvider = {
@@ -19,7 +35,7 @@ describe('PasswordField', () => {
 
   const renderWithSuggestions = (children: React.ReactNode) => {
     return render(
-      <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>{children}</SuggestionContext.Provider>,
+      <StatefulSuggestionProvider getProviders={getProvidersMock}>{children}</StatefulSuggestionProvider>,
     );
   };
 

--- a/src/form/fields/PasswordField.test.tsx
+++ b/src/form/fields/PasswordField.test.tsx
@@ -6,13 +6,7 @@ import { SuggestionContext } from '../providers/SuggestionRegistryProvider';
 import { ROOT_PATH } from '../utils';
 import { PasswordField } from './PasswordField';
 
-const StatefulSuggestionProvider = ({
-  children,
-  getProviders,
-}: {
-  children: ReactNode;
-  getProviders: jest.Mock;
-}) => {
+const StatefulSuggestionProvider = ({ children, getProviders }: { children: ReactNode; getProviders: jest.Mock }) => {
   const [currentOpenMenu, setCurrentOpenMenu] = useState<string | null>(null);
   return (
     <SuggestionContext.Provider value={{ getProviders, currentOpenMenu, setCurrentOpenMenu }}>
@@ -34,9 +28,7 @@ describe('PasswordField', () => {
   const getProvidersMock = jest.fn().mockReturnValue([mockSuggestionProvider]);
 
   const renderWithSuggestions = (children: React.ReactNode) => {
-    return render(
-      <StatefulSuggestionProvider getProviders={getProvidersMock}>{children}</StatefulSuggestionProvider>,
-    );
+    return render(<StatefulSuggestionProvider getProviders={getProvidersMock}>{children}</StatefulSuggestionProvider>);
   };
 
   beforeEach(() => {

--- a/src/form/fields/PasswordField.tsx
+++ b/src/form/fields/PasswordField.tsx
@@ -57,7 +57,7 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
     [onFieldChange],
   );
 
-  const suggestions = useSuggestions({
+  const { suggestionsMenu } = useSuggestions({
     propName,
     schema,
     inputRef,
@@ -102,7 +102,7 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
           toggleRawValueWrap={toggleRawValueWrap}
         />
       </div>
-      {suggestions}
+      {suggestionsMenu}
     </FieldWrapper>
   );
 };

--- a/src/form/fields/PasswordField.tsx
+++ b/src/form/fields/PasswordField.tsx
@@ -57,7 +57,7 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
     [onFieldChange],
   );
 
-  const { suggestionsMenu } = useSuggestions({
+  const { suggestionsMenu, openSuggestions } = useSuggestions({
     propName,
     schema,
     inputRef,
@@ -77,6 +77,7 @@ export const PasswordField: FunctionComponent<FieldProps> = ({ propName, require
       defaultValue={schema.default?.toString()}
       errors={errors}
       isRaw={isRaw}
+      onOpenSuggestions={openSuggestions}
     >
       <div className="password-field-container">
         <div className="password-field-input-wrapper">

--- a/src/form/fields/StringField.test.tsx
+++ b/src/form/fields/StringField.test.tsx
@@ -7,13 +7,7 @@ import { SchemaProvider } from '../providers/SchemaProvider';
 import { ROOT_PATH } from '../utils';
 import { StringField } from './StringField';
 
-const StatefulSuggestionProvider = ({
-  children,
-  getProviders,
-}: {
-  children: ReactNode;
-  getProviders: jest.Mock;
-}) => {
+const StatefulSuggestionProvider = ({ children, getProviders }: { children: ReactNode; getProviders: jest.Mock }) => {
   const [currentOpenMenu, setCurrentOpenMenu] = useState<string | null>(null);
   return (
     <SuggestionContext.Provider value={{ getProviders, currentOpenMenu, setCurrentOpenMenu }}>
@@ -35,9 +29,7 @@ describe('StringField', () => {
   const getProvidersMock = jest.fn().mockReturnValue([mockSuggestionProvider]);
 
   const renderWithSuggestions = (children: React.ReactNode) => {
-    return render(
-      <StatefulSuggestionProvider getProviders={getProvidersMock}>{children}</StatefulSuggestionProvider>,
-    );
+    return render(<StatefulSuggestionProvider getProviders={getProvidersMock}>{children}</StatefulSuggestionProvider>);
   };
 
   beforeEach(() => {

--- a/src/form/fields/StringField.test.tsx
+++ b/src/form/fields/StringField.test.tsx
@@ -1,10 +1,26 @@
 import { act, fireEvent, render, waitFor, within } from '@testing-library/react';
 import { JSONSchema4 } from 'json-schema';
+import { ReactNode, useState } from 'react';
 import { SuggestionContext } from '../providers';
 import { ModelContext, ModelContextProvider } from '../providers/ModelProvider';
 import { SchemaProvider } from '../providers/SchemaProvider';
 import { ROOT_PATH } from '../utils';
 import { StringField } from './StringField';
+
+const StatefulSuggestionProvider = ({
+  children,
+  getProviders,
+}: {
+  children: ReactNode;
+  getProviders: jest.Mock;
+}) => {
+  const [currentOpenMenu, setCurrentOpenMenu] = useState<string | null>(null);
+  return (
+    <SuggestionContext.Provider value={{ getProviders, currentOpenMenu, setCurrentOpenMenu }}>
+      {children}
+    </SuggestionContext.Provider>
+  );
+};
 
 describe('StringField', () => {
   const mockSuggestionProvider = {
@@ -20,7 +36,7 @@ describe('StringField', () => {
 
   const renderWithSuggestions = (children: React.ReactNode) => {
     return render(
-      <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>{children}</SuggestionContext.Provider>,
+      <StatefulSuggestionProvider getProviders={getProvidersMock}>{children}</StatefulSuggestionProvider>,
     );
   };
 

--- a/src/form/fields/StringField.tsx
+++ b/src/form/fields/StringField.tsx
@@ -85,7 +85,7 @@ export const StringField: FunctionComponent<StringFieldProps> = ({
     [onFieldChange],
   );
 
-  const { suggestionsMenu } = useSuggestions({
+  const { suggestionsMenu, openSuggestions } = useSuggestions({
     propName,
     schema,
     inputRef,
@@ -105,6 +105,7 @@ export const StringField: FunctionComponent<StringFieldProps> = ({
       defaultValue={schema.default?.toString()}
       errors={errors}
       isRaw={isRaw}
+      onOpenSuggestions={openSuggestions}
     >
       <div className="string-field-container">
         <div className="string-field-input-wrapper">

--- a/src/form/fields/StringField.tsx
+++ b/src/form/fields/StringField.tsx
@@ -85,7 +85,7 @@ export const StringField: FunctionComponent<StringFieldProps> = ({
     [onFieldChange],
   );
 
-  const suggestions = useSuggestions({
+  const { suggestionsMenu } = useSuggestions({
     propName,
     schema,
     inputRef,
@@ -134,7 +134,7 @@ export const StringField: FunctionComponent<StringFieldProps> = ({
           toggleRawValueWrap={toggleRawValueWrap}
         />
       </div>
-      {suggestions}
+      {suggestionsMenu}
       {additionalUtility}
     </FieldWrapper>
   );

--- a/src/form/fields/TextAreaField.test.tsx
+++ b/src/form/fields/TextAreaField.test.tsx
@@ -1,18 +1,40 @@
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { ReactNode, useState } from 'react';
 import { ModelContextProvider } from '../providers/ModelProvider';
 import { SchemaProvider } from '../providers/SchemaProvider';
+import { SuggestionContext } from '../providers/SuggestionRegistryProvider';
 import { ROOT_PATH } from '../utils';
 import { TextAreaField } from './TextAreaField';
 
-// Mock useSuggestions to control its output
-jest.mock('../hooks/suggestions', () => ({
-  useSuggestions: jest.fn(() => ({
-    suggestionsMenu: null,
-    openSuggestions: jest.fn(),
-  })),
-}));
+const StatefulSuggestionProvider = ({ children, getProviders }: { children: ReactNode; getProviders: jest.Mock }) => {
+  const [currentOpenMenu, setCurrentOpenMenu] = useState<string | null>(null);
+  return (
+    <SuggestionContext.Provider value={{ getProviders, currentOpenMenu, setCurrentOpenMenu }}>
+      {children}
+    </SuggestionContext.Provider>
+  );
+};
 
 describe('TextAreaField', () => {
+  const mockSuggestionProvider = {
+    id: 'test-provider',
+    appliesTo: jest.fn().mockReturnValue(true),
+    getSuggestions: jest.fn().mockResolvedValue([
+      { value: 'test-suggestion-1', description: 'First test suggestion' },
+      { value: 'test-suggestion-2', description: 'Second test suggestion' },
+    ]),
+  };
+
+  const getProvidersMock = jest.fn().mockReturnValue([mockSuggestionProvider]);
+
+  const renderWithSuggestions = (children: React.ReactNode) => {
+    return render(<StatefulSuggestionProvider getProviders={getProvidersMock}>{children}</StatefulSuggestionProvider>);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render', () => {
     const { container } = render(
       <ModelContextProvider model="Value" onPropertyChange={jest.fn()}>
@@ -127,28 +149,25 @@ describe('TextAreaField', () => {
   });
 
   it('shows suggestions when Ctrl+Space is pressed', async () => {
-    const SuggestionsMenu = () => <div data-testid="suggestions-menu">Suggestions</div>;
-    const { useSuggestions } = jest.requireMock('../hooks/suggestions');
+    const onPropertyChangeSpy = jest.fn();
 
-    useSuggestions.mockImplementation(() => ({
-      suggestionsMenu: <SuggestionsMenu />,
-      openSuggestions: jest.fn(),
-    }));
-
-    const { getByRole, getByTestId } = render(
-      <ModelContextProvider model="Value" onPropertyChange={jest.fn()}>
+    const wrapper = renderWithSuggestions(
+      <ModelContextProvider model="" onPropertyChange={onPropertyChangeSpy}>
         <TextAreaField propName={ROOT_PATH} />
       </ModelContextProvider>,
     );
-    const input = getByRole('textbox');
 
     await act(async () => {
+      const input = wrapper.getByRole('textbox');
       input.focus();
       fireEvent.keyDown(input, { code: 'Space', ctrlKey: true });
     });
 
     await waitFor(() => {
-      expect(getByTestId('suggestions-menu')).toBeInTheDocument();
+      expect(wrapper.getByTestId('suggestions-menu')).toBeInTheDocument();
     });
+
+    expect(wrapper.getByRole('menuitem', { name: 'test-suggestion-1' })).toBeInTheDocument();
+    expect(wrapper.getByRole('menuitem', { name: 'test-suggestion-2' })).toBeInTheDocument();
   });
 });

--- a/src/form/fields/TextAreaField.test.tsx
+++ b/src/form/fields/TextAreaField.test.tsx
@@ -6,7 +6,10 @@ import { TextAreaField } from './TextAreaField';
 
 // Mock useSuggestions to control its output
 jest.mock('../hooks/suggestions', () => ({
-  useSuggestions: jest.fn(() => null),
+  useSuggestions: jest.fn(() => ({
+    suggestionsMenu: null,
+    openSuggestions: jest.fn(),
+  })),
 }));
 
 describe('TextAreaField', () => {
@@ -127,7 +130,10 @@ describe('TextAreaField', () => {
     const SuggestionsMenu = () => <div data-testid="suggestions-menu">Suggestions</div>;
     const { useSuggestions } = jest.requireMock('../hooks/suggestions');
 
-    useSuggestions.mockImplementation(() => <SuggestionsMenu />);
+    useSuggestions.mockImplementation(() => ({
+      suggestionsMenu: <SuggestionsMenu />,
+      openSuggestions: jest.fn(),
+    }));
 
     const { getByRole, getByTestId } = render(
       <ModelContextProvider model="Value" onPropertyChange={jest.fn()}>

--- a/src/form/fields/TextAreaField.tsx
+++ b/src/form/fields/TextAreaField.tsx
@@ -40,7 +40,7 @@ export const TextAreaField: FunctionComponent<FieldProps> = ({ propName, require
     onChange(newValue);
   };
 
-  const { suggestionsMenu } = useSuggestions({
+  const { suggestionsMenu, openSuggestions } = useSuggestions({
     propName,
     schema,
     inputRef: textAreaRef,
@@ -60,6 +60,7 @@ export const TextAreaField: FunctionComponent<FieldProps> = ({ propName, require
       defaultValue={schema.default?.toString()}
       errors={errors}
       isRaw={isRaw}
+      onOpenSuggestions={openSuggestions}
     >
       <div className="textarea-field-container">
         <div className="textarea-field-input-wrapper">

--- a/src/form/fields/TextAreaField.tsx
+++ b/src/form/fields/TextAreaField.tsx
@@ -40,7 +40,7 @@ export const TextAreaField: FunctionComponent<FieldProps> = ({ propName, require
     onChange(newValue);
   };
 
-  const suggestions = useSuggestions({
+  const { suggestionsMenu } = useSuggestions({
     propName,
     schema,
     inputRef: textAreaRef,
@@ -87,7 +87,7 @@ export const TextAreaField: FunctionComponent<FieldProps> = ({ propName, require
           toggleRawValueWrap={toggleRawValueWrap}
         />
       </div>
-      {suggestions}
+      {suggestionsMenu}
     </FieldWrapper>
   );
 };

--- a/src/form/fields/__snapshots__/PasswordField.test.tsx.snap
+++ b/src/form/fields/__snapshots__/PasswordField.test.tsx.snap
@@ -75,6 +75,56 @@ exports[`PasswordField should render 1`] = `
           </span>
         </span>
       </span>
+      <span
+        class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--top cds--tooltip cds--icon-tooltip"
+      >
+        <div
+          class="cds--tooltip-trigger__wrapper"
+        >
+          <button
+            aria-labelledby="tooltip-_r_4_"
+            class="cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--icon-only"
+            data-testid="#__open-suggestions-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              focusable="false"
+              height="16"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11 24H21V26H11z"
+              />
+              <path
+                d="M13 28H19V30H13z"
+              />
+              <path
+                d="M16,2A10,10,0,0,0,6,12a9.19,9.19,0,0,0,3.46,7.62c1,.93,1.54,1.46,1.54,2.38h2c0-1.84-1.11-2.87-2.19-3.86A7.2,7.2,0,0,1,8,12a8,8,0,0,1,16,0,7.2,7.2,0,0,1-2.82,6.14c-1.07,1-2.18,2-2.18,3.86h2c0-.92.53-1.45,1.54-2.39A9.18,9.18,0,0,0,26,12,10,10,0,0,0,16,2Z"
+              />
+            </svg>
+          </button>
+        </div>
+        <span
+          aria-hidden="true"
+          class="cds--popover"
+          id="tooltip-_r_4_"
+          role="tooltip"
+        >
+          <span
+            class="cds--popover-content cds--tooltip-content"
+          >
+            Open suggestions (Ctrl+Space)
+          </span>
+          <span
+            class="cds--popover-caret"
+          />
+        </span>
+      </span>
     </div>
     <div
       class="password-field-container"
@@ -108,7 +158,7 @@ exports[`PasswordField should render 1`] = `
                   class="cds--tooltip-trigger__wrapper"
                 >
                   <button
-                    aria-labelledby="tooltip-_r_3_"
+                    aria-labelledby="tooltip-_r_7_"
                     class="cds--text-input--password__visibility__toggle cds--btn cds--tooltip__trigger cds--tooltip--a11y cds--tooltip--bottom cds--tooltip--align-end"
                     type="button"
                   >
@@ -135,7 +185,7 @@ exports[`PasswordField should render 1`] = `
                 <span
                   aria-hidden="true"
                   class="cds--popover"
-                  id="tooltip-_r_3_"
+                  id="tooltip-_r_7_"
                   role="tooltip"
                 >
                   <span
@@ -164,7 +214,7 @@ exports[`PasswordField should render 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
-              aria-labelledby="tooltip-_r_6_"
+              aria-labelledby="tooltip-_r_a_"
               class="cds--overflow-menu cds--overflow-menu--sm cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--icon-only"
               data-testid="#__field-actions"
               type="button"
@@ -202,7 +252,7 @@ exports[`PasswordField should render 1`] = `
           <span
             aria-hidden="true"
             class="cds--popover"
-            id="tooltip-_r_6_"
+            id="tooltip-_r_a_"
             role="tooltip"
           >
             <span

--- a/src/form/fields/__snapshots__/PasswordField.test.tsx.snap
+++ b/src/form/fields/__snapshots__/PasswordField.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`PasswordField should render 1`] = `
         class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--auto-align cds--autoalign cds--popover--bottom cds--toggletip cds--autoalign"
       >
         <button
-          aria-controls="id-_r_0_"
+          aria-controls="id-_r_1_"
           aria-expanded="false"
           aria-label="More info for # field"
           class="cds--toggletip-button"
@@ -47,7 +47,7 @@ exports[`PasswordField should render 1`] = `
         </button>
         <span
           class="cds--popover"
-          id="id-_r_0_"
+          id="id-_r_1_"
         >
           <span
             class="cds--popover-content"
@@ -108,7 +108,7 @@ exports[`PasswordField should render 1`] = `
                   class="cds--tooltip-trigger__wrapper"
                 >
                   <button
-                    aria-labelledby="tooltip-_r_2_"
+                    aria-labelledby="tooltip-_r_3_"
                     class="cds--text-input--password__visibility__toggle cds--btn cds--tooltip__trigger cds--tooltip--a11y cds--tooltip--bottom cds--tooltip--align-end"
                     type="button"
                   >
@@ -135,7 +135,7 @@ exports[`PasswordField should render 1`] = `
                 <span
                   aria-hidden="true"
                   class="cds--popover"
-                  id="tooltip-_r_2_"
+                  id="tooltip-_r_3_"
                   role="tooltip"
                 >
                   <span
@@ -164,7 +164,7 @@ exports[`PasswordField should render 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
-              aria-labelledby="tooltip-_r_5_"
+              aria-labelledby="tooltip-_r_6_"
               class="cds--overflow-menu cds--overflow-menu--sm cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--icon-only"
               data-testid="#__field-actions"
               type="button"
@@ -202,7 +202,7 @@ exports[`PasswordField should render 1`] = `
           <span
             aria-hidden="true"
             class="cds--popover"
-            id="tooltip-_r_5_"
+            id="tooltip-_r_6_"
             role="tooltip"
           >
             <span

--- a/src/form/fields/__snapshots__/StringField.test.tsx.snap
+++ b/src/form/fields/__snapshots__/StringField.test.tsx.snap
@@ -75,6 +75,56 @@ exports[`StringField should render 1`] = `
           </span>
         </span>
       </span>
+      <span
+        class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--top cds--tooltip cds--icon-tooltip"
+      >
+        <div
+          class="cds--tooltip-trigger__wrapper"
+        >
+          <button
+            aria-labelledby="tooltip-_r_4_"
+            class="cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--icon-only"
+            data-testid="#__open-suggestions-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              focusable="false"
+              height="16"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11 24H21V26H11z"
+              />
+              <path
+                d="M13 28H19V30H13z"
+              />
+              <path
+                d="M16,2A10,10,0,0,0,6,12a9.19,9.19,0,0,0,3.46,7.62c1,.93,1.54,1.46,1.54,2.38h2c0-1.84-1.11-2.87-2.19-3.86A7.2,7.2,0,0,1,8,12a8,8,0,0,1,16,0,7.2,7.2,0,0,1-2.82,6.14c-1.07,1-2.18,2-2.18,3.86h2c0-.92.53-1.45,1.54-2.39A9.18,9.18,0,0,0,26,12,10,10,0,0,0,16,2Z"
+              />
+            </svg>
+          </button>
+        </div>
+        <span
+          aria-hidden="true"
+          class="cds--popover"
+          id="tooltip-_r_4_"
+          role="tooltip"
+        >
+          <span
+            class="cds--popover-content cds--tooltip-content"
+          >
+            Open suggestions (Ctrl+Space)
+          </span>
+          <span
+            class="cds--popover-caret"
+          />
+        </span>
+      </span>
     </div>
     <div
       class="string-field-container"
@@ -126,7 +176,7 @@ exports[`StringField should render 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
-              aria-labelledby="tooltip-_r_4_"
+              aria-labelledby="tooltip-_r_8_"
               class="cds--overflow-menu cds--overflow-menu--sm cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--icon-only"
               data-testid="#__field-actions"
               type="button"
@@ -164,7 +214,7 @@ exports[`StringField should render 1`] = `
           <span
             aria-hidden="true"
             class="cds--popover"
-            id="tooltip-_r_4_"
+            id="tooltip-_r_8_"
             role="tooltip"
           >
             <span

--- a/src/form/fields/__snapshots__/StringField.test.tsx.snap
+++ b/src/form/fields/__snapshots__/StringField.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`StringField should render 1`] = `
         class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--auto-align cds--autoalign cds--popover--bottom cds--toggletip cds--autoalign"
       >
         <button
-          aria-controls="id-_r_0_"
+          aria-controls="id-_r_1_"
           aria-expanded="false"
           aria-label="More info for # field"
           class="cds--toggletip-button"
@@ -47,7 +47,7 @@ exports[`StringField should render 1`] = `
         </button>
         <span
           class="cds--popover"
-          id="id-_r_0_"
+          id="id-_r_1_"
         >
           <span
             class="cds--popover-content"
@@ -126,7 +126,7 @@ exports[`StringField should render 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
-              aria-labelledby="tooltip-_r_3_"
+              aria-labelledby="tooltip-_r_4_"
               class="cds--overflow-menu cds--overflow-menu--sm cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--icon-only"
               data-testid="#__field-actions"
               type="button"
@@ -164,7 +164,7 @@ exports[`StringField should render 1`] = `
           <span
             aria-hidden="true"
             class="cds--popover"
-            id="tooltip-_r_3_"
+            id="tooltip-_r_4_"
             role="tooltip"
           >
             <span

--- a/src/form/fields/__snapshots__/TextAreaField.test.tsx.snap
+++ b/src/form/fields/__snapshots__/TextAreaField.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`TextAreaField should render 1`] = `
         class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--auto-align cds--autoalign cds--popover--bottom cds--toggletip cds--autoalign"
       >
         <button
-          aria-controls="id-_r_0_"
+          aria-controls="id-_r_1_"
           aria-expanded="false"
           aria-label="More info for # field"
           class="cds--toggletip-button"
@@ -47,7 +47,7 @@ exports[`TextAreaField should render 1`] = `
         </button>
         <span
           class="cds--popover"
-          id="id-_r_0_"
+          id="id-_r_1_"
         >
           <span
             class="cds--popover-content"
@@ -73,6 +73,56 @@ exports[`TextAreaField should render 1`] = `
               class="cds--popover-caret cds--popover--auto-align"
             />
           </span>
+        </span>
+      </span>
+      <span
+        class="cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--top cds--tooltip cds--icon-tooltip"
+      >
+        <div
+          class="cds--tooltip-trigger__wrapper"
+        >
+          <button
+            aria-labelledby="tooltip-_r_4_"
+            class="cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--icon-only"
+            data-testid="#__open-suggestions-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              focusable="false"
+              height="16"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11 24H21V26H11z"
+              />
+              <path
+                d="M13 28H19V30H13z"
+              />
+              <path
+                d="M16,2A10,10,0,0,0,6,12a9.19,9.19,0,0,0,3.46,7.62c1,.93,1.54,1.46,1.54,2.38h2c0-1.84-1.11-2.87-2.19-3.86A7.2,7.2,0,0,1,8,12a8,8,0,0,1,16,0,7.2,7.2,0,0,1-2.82,6.14c-1.07,1-2.18,2-2.18,3.86h2c0-.92.53-1.45,1.54-2.39A9.18,9.18,0,0,0,26,12,10,10,0,0,0,16,2Z"
+              />
+            </svg>
+          </button>
+        </div>
+        <span
+          aria-hidden="true"
+          class="cds--popover"
+          id="tooltip-_r_4_"
+          role="tooltip"
+        >
+          <span
+            class="cds--popover-content cds--tooltip-content"
+          >
+            Open suggestions (Ctrl+Space)
+          </span>
+          <span
+            class="cds--popover-caret"
+          />
         </span>
       </span>
     </div>
@@ -126,7 +176,7 @@ exports[`TextAreaField should render 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
-              aria-labelledby="tooltip-_r_4_"
+              aria-labelledby="tooltip-_r_9_"
               class="cds--overflow-menu cds--overflow-menu--sm cds--btn cds--btn--sm cds--layout--size-sm cds--btn--ghost cds--btn--icon-only"
               data-testid="#__field-actions"
               type="button"
@@ -164,7 +214,7 @@ exports[`TextAreaField should render 1`] = `
           <span
             aria-hidden="true"
             class="cds--popover"
-            id="tooltip-_r_4_"
+            id="tooltip-_r_9_"
             role="tooltip"
           >
             <span

--- a/src/form/hooks/suggestions.test.tsx
+++ b/src/form/hooks/suggestions.test.tsx
@@ -4,6 +4,21 @@ import { SuggestionProvider } from '../models/suggestions';
 import { SuggestionContext } from '../providers';
 import { useSuggestions } from './suggestions';
 
+const StatefulSuggestionProvider = ({
+  children,
+  getProviders,
+}: {
+  children: ReactNode;
+  getProviders: jest.Mock;
+}) => {
+  const [currentOpenMenu, setCurrentOpenMenu] = useState<string | null>(null);
+  return (
+    <SuggestionContext.Provider value={{ getProviders, currentOpenMenu, setCurrentOpenMenu }}>
+      {children}
+    </SuggestionContext.Provider>
+  );
+};
+
 describe('useSuggestions', () => {
   let setValueMock: jest.Mock;
   let mockProvider: SuggestionProvider;
@@ -13,7 +28,7 @@ describe('useSuggestions', () => {
     const inputRef = useRef<HTMLInputElement>(null);
     const [value, setValue] = useState<string | number>('');
 
-    const suggestions = useSuggestions({
+    const { suggestionsMenu } = useSuggestions({
       propName: 'testProp',
       schema: { type: 'string' },
       value,
@@ -38,7 +53,7 @@ describe('useSuggestions', () => {
           aria-label="Test input"
         />
 
-        {suggestions}
+        {suggestionsMenu}
 
         <button type="button">Secondary focus</button>
       </>
@@ -47,7 +62,7 @@ describe('useSuggestions', () => {
 
   const renderWithContext = (children: ReactNode) => {
     return render(
-      <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>{children}</SuggestionContext.Provider>,
+      <StatefulSuggestionProvider getProviders={getProvidersMock}>{children}</StatefulSuggestionProvider>,
     );
   };
 
@@ -75,35 +90,31 @@ describe('useSuggestions', () => {
     const inputElement = document.createElement('input');
     const inputRef = { current: inputElement };
 
-    let result: ReactNode;
-
-    await act(async () => {
-      const hookResult = renderHook(
-        () =>
-          useSuggestions({
-            inputRef,
-            propName: 'testProp',
-            schema: { type: 'string' },
-            value: '',
-            setValue: setValueMock,
-          }),
-        {
-          wrapper: ({ children }) => (
-            <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>
-              {children}
-            </SuggestionContext.Provider>
-          ),
-        },
-      );
-
-      result = hookResult.result.current;
-    });
+    const { result } = renderHook(
+      () =>
+        useSuggestions({
+          inputRef,
+          propName: 'testProp',
+          schema: { type: 'string' },
+          value: '',
+          setValue: setValueMock,
+        }),
+      {
+        wrapper: ({ children }) => (
+          <SuggestionContext.Provider
+            value={{ getProviders: getProvidersMock, currentOpenMenu: null, setCurrentOpenMenu: jest.fn() }}
+          >
+            {children}
+          </SuggestionContext.Provider>
+        ),
+      },
+    );
 
     await waitFor(() => {
       expect(mockProvider.getSuggestions).not.toHaveBeenCalled();
     });
 
-    expect(result).toBeDefined();
+    expect(result.current.suggestionsMenu).toBeNull();
   });
 
   it('should handle setValue being undefined', () => {
@@ -116,7 +127,11 @@ describe('useSuggestions', () => {
 
     const { result } = renderHook(() => useSuggestions(propsWithoutSetValue), {
       wrapper: ({ children }) => (
-        <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>{children}</SuggestionContext.Provider>
+        <SuggestionContext.Provider
+          value={{ getProviders: getProvidersMock, currentOpenMenu: null, setCurrentOpenMenu: jest.fn() }}
+        >
+          {children}
+        </SuggestionContext.Provider>
       ),
     });
 
@@ -139,7 +154,9 @@ describe('useSuggestions', () => {
           }),
         {
           wrapper: ({ children }) => (
-            <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>
+            <SuggestionContext.Provider
+              value={{ getProviders: getProvidersMock, currentOpenMenu: null, setCurrentOpenMenu: jest.fn() }}
+            >
               {children}
             </SuggestionContext.Provider>
           ),
@@ -175,7 +192,9 @@ describe('useSuggestions', () => {
           }),
         {
           wrapper: ({ children }) => (
-            <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>
+            <SuggestionContext.Provider
+              value={{ getProviders: getProvidersMock, currentOpenMenu: null, setCurrentOpenMenu: jest.fn() }}
+            >
               {children}
             </SuggestionContext.Provider>
           ),
@@ -205,7 +224,11 @@ describe('useSuggestions', () => {
 
     const { rerender } = renderHook(() => useSuggestions(props), {
       wrapper: ({ children }) => (
-        <SuggestionContext.Provider value={{ getProviders: getProvidersMock }}>{children}</SuggestionContext.Provider>
+        <SuggestionContext.Provider
+          value={{ getProviders: getProvidersMock, currentOpenMenu: null, setCurrentOpenMenu: jest.fn() }}
+        >
+          {children}
+        </SuggestionContext.Provider>
       ),
     });
 

--- a/src/form/hooks/suggestions.tsx
+++ b/src/form/hooks/suggestions.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -23,15 +24,29 @@ type UseSuggestionsProps = {
   value: string | number;
   setValue?: (value: string) => void;
 };
-export const useSuggestions = ({ propName, schema, inputRef, value, setValue }: UseSuggestionsProps): ReactNode => {
-  const [isVisible, setIsVisible] = useState(false);
+
+type UseSuggestionsReturn = {
+  suggestionsMenu: ReactNode;
+  openSuggestions: () => void;
+};
+
+export const useSuggestions = ({
+  propName,
+  schema,
+  inputRef,
+  value,
+  setValue,
+}: UseSuggestionsProps): UseSuggestionsReturn => {
+  const menuId = `${propName}-${useId()}`;
   const [searchValue, setSearchValue] = useState('');
   const [groupedSuggestions, setGroupedSuggestions] = useState<GroupedSuggestions>({ root: [] });
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
   const menuRef = useRef<HTMLDivElement>(null);
   const firstElementRef = useRef<HTMLLIElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const { getProviders } = useContext(SuggestionContext);
+  const { getProviders, currentOpenMenu, setCurrentOpenMenu } = useContext(SuggestionContext);
+
+  const isVisible = currentOpenMenu === menuId;
 
   const suggestionProviders: SuggestionProvider[] = useMemo(
     () => getProviders(propName, schema),
@@ -41,12 +56,12 @@ export const useSuggestions = ({ propName, schema, inputRef, value, setValue }: 
   const onEscapeKey = useCallback(
     (event: React.KeyboardEvent | KeyboardEvent) => {
       event.preventDefault();
-      setIsVisible(false);
+      setCurrentOpenMenu(null);
       requestAnimationFrame(() => {
         inputRef.current?.focus();
       });
     },
-    [inputRef],
+    [inputRef, setCurrentOpenMenu],
   );
 
   const handleInputKeyDown = useCallback(
@@ -56,29 +71,25 @@ export const useSuggestions = ({ propName, schema, inputRef, value, setValue }: 
       if ((event.ctrlKey && event.code === 'Space') || (event.altKey && event.code === 'Escape')) {
         event.preventDefault();
         setSearchValue('');
-        setIsVisible(true);
-        requestAnimationFrame(() => {
-          firstElementRef.current?.focus();
-          firstElementRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
-        });
+        setCurrentOpenMenu(menuId);
       } else if (event.key === 'Escape') {
         onEscapeKey(event);
       }
     },
-    [onEscapeKey],
+    [onEscapeKey, setCurrentOpenMenu, menuId],
   );
 
   const getHandleOnClick = useCallback(
     (inputValue: string | number, suggestion: Suggestion) => () => {
       const { newValue, cursorPosition } = applySuggestion(suggestion, inputValue, inputRef.current?.selectionStart);
 
-      setIsVisible(false);
+      setCurrentOpenMenu(null);
       setValue?.(newValue);
 
       inputRef.current?.focus();
       inputRef.current?.setSelectionRange(cursorPosition, cursorPosition);
     },
-    [inputRef, setValue],
+    [inputRef, setValue, setCurrentOpenMenu],
   );
 
   const getHandleMenuKeyDown = useCallback(
@@ -140,33 +151,6 @@ export const useSuggestions = ({ propName, schema, inputRef, value, setValue }: 
     };
   }, [suggestionProviders, value, propName, inputRef, isVisible, searchValue]);
 
-  /** Register keyboard bindings */
-  useEffect(() => {
-    const input = inputRef.current;
-    if (!input) return;
-
-    const handleFocus = () => {
-      input.addEventListener('keydown', handleInputKeyDown);
-    };
-    const handleBlur = () => {
-      input.removeEventListener('keydown', handleInputKeyDown);
-    };
-
-    input.addEventListener('focus', handleFocus);
-    input.addEventListener('blur', handleBlur);
-
-    // If already focused, register immediately
-    if (document.activeElement === input) {
-      handleFocus();
-    }
-
-    return () => {
-      input.removeEventListener('focus', handleFocus);
-      input.removeEventListener('blur', handleBlur);
-      input.removeEventListener('keydown', handleInputKeyDown);
-    };
-  }, [handleInputKeyDown, inputRef]);
-
   const focusOnSearchInput = useCallback(() => {
     searchInputRef.current?.focus();
   }, []);
@@ -194,6 +178,38 @@ export const useSuggestions = ({ propName, schema, inputRef, value, setValue }: 
     [onEscapeKey],
   );
 
+  const openSuggestions = useCallback(() => {
+    setSearchValue('');
+    setCurrentOpenMenu((prev) => (prev === menuId ? null : menuId));
+  }, [menuId, setCurrentOpenMenu]);
+
+  /** Register keyboard bindings */
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+
+    const handleFocus = () => {
+      input.addEventListener('keydown', handleInputKeyDown);
+    };
+    const handleBlur = () => {
+      input.removeEventListener('keydown', handleInputKeyDown);
+    };
+
+    input.addEventListener('focus', handleFocus);
+    input.addEventListener('blur', handleBlur);
+
+    // If already focused, register immediately
+    if (document.activeElement === input) {
+      handleFocus();
+    }
+
+    return () => {
+      input.removeEventListener('focus', handleFocus);
+      input.removeEventListener('blur', handleBlur);
+      input.removeEventListener('keydown', handleInputKeyDown);
+    };
+  }, [handleInputKeyDown, inputRef]);
+
   useEffect(() => {
     if (!isVisible || !inputRef.current) return;
 
@@ -220,9 +236,7 @@ export const useSuggestions = ({ propName, schema, inputRef, value, setValue }: 
     });
   }, [isVisible, groupedSuggestions]);
 
-  if (!isVisible) return null;
-
-  return (
+  const suggestionsMenu = isVisible ? (
     <Layer level={1}>
       <div ref={menuRef} data-testid="suggestions-menu">
         <Menu
@@ -291,5 +305,10 @@ export const useSuggestions = ({ propName, schema, inputRef, value, setValue }: 
         </Menu>
       </div>
     </Layer>
-  );
+  ) : null;
+
+  return {
+    suggestionsMenu,
+    openSuggestions,
+  };
 };

--- a/src/form/hooks/suggestions.tsx
+++ b/src/form/hooks/suggestions.tsx
@@ -179,11 +179,14 @@ export const useSuggestions = ({
   );
 
   const openSuggestions = useCallback(() => {
+    const input = inputRef.current;
+    if (input?.disabled || input?.readOnly) return;
+
     setSearchValue('');
     setCurrentOpenMenu((prev) => (prev === menuId ? null : menuId));
-  }, [menuId, setCurrentOpenMenu]);
+  }, [menuId, setCurrentOpenMenu, inputRef]);
 
-  /** Register keyboard bindings */
+  /** Register keyboard bindings and double-click handler */
   useEffect(() => {
     const input = inputRef.current;
     if (!input) return;
@@ -197,6 +200,7 @@ export const useSuggestions = ({
 
     input.addEventListener('focus', handleFocus);
     input.addEventListener('blur', handleBlur);
+    input.addEventListener('dblclick', openSuggestions);
 
     // If already focused, register immediately
     if (document.activeElement === input) {
@@ -207,8 +211,9 @@ export const useSuggestions = ({
       input.removeEventListener('focus', handleFocus);
       input.removeEventListener('blur', handleBlur);
       input.removeEventListener('keydown', handleInputKeyDown);
+      input.removeEventListener('dblclick', openSuggestions);
     };
-  }, [handleInputKeyDown, inputRef]);
+  }, [handleInputKeyDown, inputRef, openSuggestions]);
 
   useEffect(() => {
     if (!isVisible || !inputRef.current) return;
@@ -221,20 +226,13 @@ export const useSuggestions = ({
       left: rect.left + window.scrollX,
     });
 
-    requestAnimationFrame(() => {
+    /** Use setTimeout to ensure focus happens after Carbon Menu's initialization */
+    const focusTimeout = setTimeout(() => {
       searchInputRef.current?.focus();
-    });
-  }, [isVisible, inputRef]);
+    }, 100);
 
-  useEffect(() => {
-    if (!isVisible) return;
-
-    requestAnimationFrame(() => {
-      if (document.activeElement !== searchInputRef.current) {
-        searchInputRef.current?.focus();
-      }
-    });
-  }, [isVisible, groupedSuggestions]);
+    return () => clearTimeout(focusTimeout);
+  }, [isVisible, inputRef, groupedSuggestions]);
 
   const suggestionsMenu = isVisible ? (
     <Layer level={1}>

--- a/src/form/providers/SuggestionRegistryProvider.tsx
+++ b/src/form/providers/SuggestionRegistryProvider.tsx
@@ -6,17 +6,24 @@ interface SuggestionContextApi {
   registerProvider: (provider: SuggestionProvider) => void;
   unregisterProvider: (id: string) => void;
 }
+type MenuStateSetter = (menuId: string | null | ((prev: string | null) => string | null)) => void;
+
 interface SuggestionContext {
   getProviders: (propertyName: string, schema: JSONSchema4) => SuggestionProvider[];
+  currentOpenMenu: string | null;
+  setCurrentOpenMenu: MenuStateSetter;
 }
 
 export const SuggestionContextApi = createContext<SuggestionContextApi | undefined | null>(undefined);
 export const SuggestionContext = createContext<SuggestionContext>({
   getProviders: () => [],
+  currentOpenMenu: null,
+  setCurrentOpenMenu: () => {},
 });
 
 export const SuggestionRegistryProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
   const [providers, setProviders] = useState<SuggestionProvider[]>([]);
+  const [currentOpenMenu, setCurrentOpenMenu] = useState<string | null>(null);
 
   const registerProvider = useCallback((provider: SuggestionProvider) => {
     setProviders((prevProviders) => {
@@ -48,9 +55,18 @@ export const SuggestionRegistryProvider: FunctionComponent<PropsWithChildren> = 
     [registerProvider, unregisterProvider],
   );
 
+  const contextValue = useMemo(
+    () => ({
+      getProviders,
+      currentOpenMenu,
+      setCurrentOpenMenu,
+    }),
+    [getProviders, currentOpenMenu],
+  );
+
   return (
     <SuggestionContextApi.Provider value={contextApi}>
-      <SuggestionContext.Provider value={{ getProviders }}>{children}</SuggestionContext.Provider>
+      <SuggestionContext.Provider value={contextValue}>{children}</SuggestionContext.Provider>
     </SuggestionContextApi.Provider>
   );
 };


### PR DESCRIPTION
## Summary

- Centralize suggestion menu visibility state in `SuggestionContext` so only one menu can be open at a time across all fields
- Change `useSuggestions` return type to `{ suggestionsMenu, openSuggestions }` for better composability
- Add lightbulb (Idea) icon button in field label row for opening the suggestions menu
- Add double-click handler on input fields to toggle suggestions
- Guard against opening suggestions on disabled/readOnly inputs
- Use `setTimeout` to reliably focus the search input after Carbon Menu's internal focus management



https://github.com/user-attachments/assets/19b71629-8060-4ad1-8572-f61cb54fa963



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a suggestion (Idea) button in field labels to open autocomplete.
  * Fields can now trigger an explicit open-suggestions action.

* **Behavior**
  * Suggestion menus are centrally managed so only one menu is open at a time.
  * Opening/closing and keyboard interactions (Ctrl+Space, Escape, double-click) refined for consistent behavior.

* **Tests**
  * Tests updated to exercise real, stateful suggestion menus and assert rendered suggestion items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->