### PR TITLE
Fix no-field message when All tab is selected

### DIFF
--- a/src/form/Form/NoFieldFound.test.tsx
+++ b/src/form/Form/NoFieldFound.test.tsx
@@ -19,6 +19,23 @@ describe('NoFieldFound Component', () => {
     expect(screen.getByText('No Required fields found')).toBeInTheDocument();
   });
 
+  it('should not suggest switching tabs when the All tab is already selected', () => {
+    const mockContextValue: CanvasFormTabsContextResult = {
+      selectedTab: 'All',
+      setSelectedTab: jest.fn(),
+    };
+
+    render(
+      <CanvasFormTabsContext.Provider value={mockContextValue}>
+        <NoFieldFound />
+      </CanvasFormTabsContext.Provider>,
+    );
+
+    expect(screen.getByText('No fields found')).toBeInTheDocument();
+    expect(screen.getByText('No field found matching this criteria.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /All/i })).not.toBeInTheDocument();
+  });
+
   it('should call onTabChange when the button is clicked', () => {
     const mockContextValue: CanvasFormTabsContextResult = {
       selectedTab: 'Required',

--- a/src/form/Form/NoFieldFound.tsx
+++ b/src/form/Form/NoFieldFound.tsx
@@ -4,22 +4,32 @@ import { CanvasFormTabsContext } from '../providers/canvas-form-tabs.provider';
 
 export const NoFieldFound: FunctionComponent<{ className?: string }> = (props) => {
   const canvasFormTabsContext = useContext(CanvasFormTabsContext);
+  const isAllTabSelected = canvasFormTabsContext.selectedTab === 'All';
 
   return (
     <Card data-testid="no-field-found" className={props.className}>
       <CardBody>
-        <Alert variant="info" title={`No ${canvasFormTabsContext.selectedTab} fields found`}>
-          No field found matching this criteria. Please switch to the{' '}
-          <Button
-            onClick={() => {
-              canvasFormTabsContext.setSelectedTab('All');
-            }}
-            variant="link"
-            isInline
-          >
-            <b>All</b>
-          </Button>{' '}
-          tab.
+        <Alert
+          variant="info"
+          title={isAllTabSelected ? 'No fields found' : `No ${canvasFormTabsContext.selectedTab} fields found`}
+        >
+          No field found matching this criteria.
+          {!isAllTabSelected && (
+            <>
+              {' '}
+              Please switch to the{' '}
+              <Button
+                onClick={() => {
+                  canvasFormTabsContext.setSelectedTab('All');
+                }}
+                variant="link"
+                isInline
+              >
+                <b>All</b>
+              </Button>{' '}
+              tab.
+            </>
+          )}
         </Alert>
       </CardBody>
     </Card>


### PR DESCRIPTION
### Description

Addresses downstream issue KaotoIO/kaoto#3281.

When the form empty state is shown while the selected tab is already `All`, `NoFieldFound` currently still prompts users to switch to the All tab. This keeps the existing switch action for `Required` / `Modified`, but renders a plain no-results message when `All` is already selected.

#### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update
- [ ] Other (please describe)

#### How Has This Been Tested?

- `corepack yarn test src/form/Form/NoFieldFound.test.tsx --runInBand`
- `corepack yarn test --runInBand`
- `corepack yarn build:lib`
- `corepack yarn prettier --check src/form/Form/NoFieldFound.tsx src/form/Form/NoFieldFound.test.tsx`
- `corepack yarn eslint src/form/Form/NoFieldFound.tsx src/form/Form/NoFieldFound.test.tsx`

#### Checklist
- [x] I have read the Contributing Guidelines.
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [x] I have updated any relevant documentation.
- [x] I have added tests that prove my fix or feature works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved "no fields found" messaging to avoid redundant suggestions when already viewing all fields.
  * Updated alert text to display contextually appropriate messages based on the current tab selection.

* **Tests**
  * Added test coverage for tab-switch suggestion behavior when the All tab is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->