### PR TITLE
fix(sonarqube): typescript S6481 fix

### DIFF
--- a/src/form/providers/filtered-field.provider.tsx
+++ b/src/form/providers/filtered-field.provider.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, PropsWithChildren, createContext, useCallback } from 'react';
+import { FunctionComponent, PropsWithChildren, createContext, useCallback, useMemo } from 'react';
 import { useDebounceValue } from 'usehooks-ts';
 
 export interface FilteredFieldContextResult {
@@ -24,15 +24,14 @@ export const FilteredFieldProvider: FunctionComponent<PropsWithChildren> = (prop
     [setSearchTerm],
   );
 
-  return (
-    <FilteredFieldContext.Provider
-      value={{
-        filteredFieldText: searchTerm,
-        onFilterChange,
-        isGroupExpanded: searchTerm.length > 0,
-      }}
-    >
-      {props.children}
-    </FilteredFieldContext.Provider>
+  const contextValue = useMemo(
+    () => ({
+      filteredFieldText: searchTerm,
+      onFilterChange,
+      isGroupExpanded: searchTerm.length > 0,
+    }),
+    [searchTerm, onFilterChange],
   );
+
+  return <FilteredFieldContext.Provider value={contextValue}>{props.children}</FilteredFieldContext.Provider>;
 };


### PR DESCRIPTION
fix sonarqube issue typescript S6481 - “The value object passed as the value prop to the Context provider changes every render. To fix this consider wrapping it in a useMemo hook.”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved form filtering efficiency by stabilizing shared filtering state between renders.
  * Preserved existing filtering behavior, including text updates and automatic group expansion during searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->